### PR TITLE
chore: removes uv.lock from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 emulator/
 poetry.lock
-uv.lock
 .python-version
 
 # Byte-compiled / optimized / DLL files


### PR DESCRIPTION
Changes to the lock file should be reflected in the repository as the github release action expects the uv.lock file.