### PR TITLE
Updates tiqi zedboard dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ server = [
     "psutil>=7.0.0",
 ]
 zedboard = [
-    "tiqi-zedboard @ git+ssh://git@gitlab.phys.ethz.ch/tiqi-projects/drivers/tiqi-zedboard.git",
+    "tiqi-zedboard @ git+ssh://git@gitlab.phys.ethz.ch/tiqi-projects/drivers/tiqi-zedboard.git@v1.3.0",
 ]
 client = [
     "ipympl>=0.9.5",

--- a/src/icon/logging.py
+++ b/src/icon/logging.py
@@ -39,6 +39,9 @@ LOGGING_CONFIG = {
             "propagate": False,
         },
         "icon": {"handlers": ["default"], "propagate": False},  # level set at runtime
+        "tiqi_zedboard": {
+            "handlers": ["default"],
+        },  # level set at runtime
         "pydase": {"handlers": ["default"], "propagate": False},  # level set at runtime
         "asyncio": {"handlers": ["default"], "level": logging.INFO, "propagate": True},
         "socketio": {
@@ -79,6 +82,7 @@ def setup_logging(log_level: int) -> None:
     LOGGING_CONFIG["loggers"]["pydase"]["level"] = log_level
     LOGGING_CONFIG["loggers"]["alembic"]["level"] = log_level
     LOGGING_CONFIG["loggers"]["aiohttp"]["level"] = log_level
+    LOGGING_CONFIG["loggers"]["tiqi_zedboard"]["level"] = log_level
     logging.config.dictConfig(LOGGING_CONFIG)
 
     logger.info("Configured log level: %s", logging.getLevelName(log_level))

--- a/uv.lock
+++ b/uv.lock
@@ -1188,7 +1188,7 @@ requires-dist = [
     { name = "pytz", specifier = ">=2024.2" },
     { name = "sqlalchemy", marker = "extra == 'server'", specifier = ">=2.0.36" },
     { name = "tables", marker = "extra == 'server'", specifier = ">=3.10.1" },
-    { name = "tiqi-zedboard", marker = "extra == 'zedboard'", git = "ssh://git@gitlab.phys.ethz.ch/tiqi-projects/drivers/tiqi-zedboard.git" },
+    { name = "tiqi-zedboard", marker = "extra == 'zedboard'", git = "ssh://git@gitlab.phys.ethz.ch/tiqi-projects/drivers/tiqi-zedboard.git?rev=v1.3.0" },
 ]
 provides-extras = ["server", "zedboard", "client"]
 
@@ -3807,16 +3807,16 @@ wheels = [
 
 [[package]]
 name = "tiqi-rpc"
-version = "2.0.0"
-source = { git = "ssh://git@gitlab.phys.ethz.ch/tiqi-projects/tiqi-rpc-python.git?rev=v1.0.0#6d178efabcb190966d5b78e1e3d4960c1a3357d5" }
+version = "2.1.0"
+source = { git = "ssh://git@gitlab.phys.ethz.ch/tiqi-projects/tiqi-rpc-python.git?rev=v2.1.0#7bfb0094f1796056fa85671072d53f1100e0f7b9" }
 dependencies = [
     { name = "msgpack" },
 ]
 
 [[package]]
 name = "tiqi-zedboard"
-version = "0.1.0"
-source = { git = "ssh://git@gitlab.phys.ethz.ch/tiqi-projects/drivers/tiqi-zedboard.git#7b001093f1ef1e0271bff0ff92e8c6eebad391fe" }
+version = "1.3.0"
+source = { git = "ssh://git@gitlab.phys.ethz.ch/tiqi-projects/drivers/tiqi-zedboard.git?rev=v1.3.0#c1aeb05cb3d503d1177ff4451313782047948dba" }
 dependencies = [
     { name = "msgpack" },
     { name = "tiqi-rpc" },


### PR DESCRIPTION
The new version updates
- logging: it uses `logging` instead of print statements, so we can configure the logging properly
- connection timeout handling: `tiqi_zedboard.Zedboard` accepts a timeout argument now (defaulting to 5 seconds). This should prevent some clients to hang.