### PR TITLE
Fix: pre processing logic

### DIFF
--- a/src/icon/server/pre_processing/worker.py
+++ b/src/icon/server/pre_processing/worker.py
@@ -172,13 +172,14 @@ class PreProcessingWorker(multiprocessing.Process):
 
             while True:
                 self._pre_processing_task = self._queue.get()
-                # empty update queue
-                self._handle_parameter_updates()
 
                 self._data_points_to_process = self._manager.Queue()
                 self._processed_data_points = self._manager.Queue()
 
                 try:
+                    # empty update queue
+                    self._handle_parameter_updates()
+
                     if job_run_cancelled_or_failed(
                         job_id=self._pre_processing_task.job.id,
                     ):

--- a/src/icon/server/pre_processing/worker.py
+++ b/src/icon/server/pre_processing/worker.py
@@ -177,6 +177,11 @@ class PreProcessingWorker(multiprocessing.Process):
                 self._processed_data_points = self._manager.Queue()
 
                 try:
+                    JobRunRepository.update_run_by_id(
+                        run_id=self._pre_processing_task.job_run.id,
+                        status=JobRunStatus.PROCESSING,
+                    )
+
                     # empty update queue
                     self._handle_parameter_updates()
 
@@ -233,11 +238,6 @@ class PreProcessingWorker(multiprocessing.Process):
                         repetitions=self._pre_processing_task.job.repetitions,
                         parameters=self._pre_processing_task.job.scan_parameters,
                         readout_metadata=readout_metadata,
-                    )
-
-                    JobRunRepository.update_run_by_id(
-                        run_id=self._pre_processing_task.job_run.id,
-                        status=JobRunStatus.PROCESSING,
                     )
 
                     if len(self._scan_parameter_value_combinations) > 0:


### PR DESCRIPTION
- updates JobRunStatus to PROCESSING right after getting the task
    When not setting the status at the beginning, exceptions that occur before might prevent the update to happen at all.
- moves all the logic of the pre-processing worker into the try...catch block to prevent the worker to crash when an exception happens