### PR TITLE
Refactor hardware connection check to avoid redundant status retrieval

### DIFF
--- a/src/icon/server/api/status_controller.py
+++ b/src/icon/server/api/status_controller.py
@@ -29,14 +29,14 @@ class StatusController(pydase.DataService):
         emit_queue.put({"event": "status.influxdb", "data": status})
 
     async def check_hardware_status(self) -> None:
+        status = self.__hardware_controller.connected
+
         if (
-            not self.__hardware_controller.connected
+            not status
             or self.__hardware_controller._host != get_config().hardware.host
             or self.__hardware_controller._port != get_config().hardware.port
         ):
             await asyncio.to_thread(self.__hardware_controller.connect)
-
-        status = self.__hardware_controller.connected
 
         self._hardware_available = status
         emit_queue.put({"event": "status.hardware", "data": status})


### PR DESCRIPTION
Store `self.__hardware_controller.connected` in a local `status` variable before the conditional check, instead of re-evaluating it after the check.