### PR TITLE
perf: reduce unnecessary re-renders in parameter components and hooks

### DIFF
--- a/frontend/src/components/parameterComponents/Button.tsx
+++ b/frontend/src/components/parameterComponents/Button.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useCallback } from "react";
 import { updateParameterValue } from "../../utils/updateParameterValue";
 import { useParameter } from "../../hooks/useParameter";
 import { BaseButton } from "./BaseButton";
@@ -30,10 +30,13 @@ export const ButtonComponent = React.memo(
   }: ButtonComponentProps) => {
     const [value, setValue] = useParameter(id);
     const displayValue = Boolean(value ?? defaultValue);
-    const onClick = (newValue: boolean) => {
-      updateParameterValue(id, newValue);
-      setValue(newValue);
-    };
+    const onClick = useCallback(
+      (newValue: boolean) => {
+        updateParameterValue(id, newValue);
+        setValue(newValue);
+      },
+      [id, setValue],
+    );
 
     return (
       <BaseButton

--- a/frontend/src/components/parameterComponents/Combobox.tsx
+++ b/frontend/src/components/parameterComponents/Combobox.tsx
@@ -8,6 +8,7 @@ import {
   Typography,
 } from "@mui/material";
 import { HelpButton } from "../HelpButtonComponent";
+import React, { useCallback, useEffect } from "react";
 
 interface ComboboxProps {
   id: string;
@@ -16,36 +17,36 @@ interface ComboboxProps {
   allowedValues: string[];
 }
 
-export const Combobox = ({
-  id,
-  defaultValue,
-  displayName,
-  allowedValues,
-}: ComboboxProps) => {
-  const [value, setValue] = useParameter(id);
-  const displayValue = value ?? defaultValue;
+export const Combobox = React.memo(
+  ({ id, defaultValue, displayName, allowedValues }: ComboboxProps) => {
+    const [value, setValue] = useParameter(id);
+    const displayValue = value ?? defaultValue;
 
-  const handleChange = (event: SelectChangeEvent<string | number | boolean>) => {
-    const newValue = event.target.value;
-    updateParameterValue(id, newValue);
-    setValue(newValue);
-  };
+    const handleChange = useCallback(
+      (event: SelectChangeEvent<string | number | boolean>) => {
+        const newValue = event.target.value;
+        updateParameterValue(id, newValue);
+        setValue(newValue);
+      },
+      [id, setValue],
+    );
 
-  return (
-    <div style={{ display: "flex", alignItems: "center", gap: "8px" }}>
+    return (
       <div style={{ display: "flex", alignItems: "center", gap: "8px" }}>
-        <Typography noWrap>{displayName ?? id}</Typography>
-        {id && <HelpButton docString={id} />}
+        <div style={{ display: "flex", alignItems: "center", gap: "8px" }}>
+          <Typography noWrap>{displayName ?? id}</Typography>
+          {id && <HelpButton docString={id} />}
+        </div>
+        <FormControl size="small">
+          <Select value={displayValue} onChange={handleChange}>
+            {allowedValues.map((value) => (
+              <MenuItem key={value} value={value}>
+                {value}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
       </div>
-      <FormControl size="small">
-        <Select value={displayValue} onChange={handleChange}>
-          {allowedValues.map((value) => (
-            <MenuItem key={value} value={value}>
-              {value}
-            </MenuItem>
-          ))}
-        </Select>
-      </FormControl>
-    </div>
-  );
-};
+    );
+  },
+);

--- a/frontend/src/components/parameterComponents/ParameterNumberComponent.tsx
+++ b/frontend/src/components/parameterComponents/ParameterNumberComponent.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useCallback, useState } from "react";
 import { useParameter } from "../../hooks/useParameter";
 import { updateParameterValue } from "../../utils/updateParameterValue";
 import { numberValid } from "../../utils/numberValid";
@@ -44,17 +44,21 @@ export const ParameterNumberComponent = React.memo(
 
     const handleChange = (val: string) => setValue(val);
 
-    const handleBlur = (newValue: string) => {
-      const parsedValue = Number.parseFloat(newValue);
+    const handleBlur = useCallback(
+      (newValue: string) => {
+        const parsedValue = Number.parseFloat(newValue);
 
-      if (numberValid(newValue, minValue, maxValue)) {
-        updateParameterValue(id, parsedValue);
-        setError(false);
-      } else {
-        setError(true);
-      }
-    };
+        if (numberValid(newValue, minValue, maxValue)) {
+          updateParameterValue(id, parsedValue);
+          setError(false);
+        } else {
+          setError(true);
+        }
+      },
+      [setError, id],
+    );
 
+    console.log("something changed");
     return (
       <Input
         id={id}

--- a/frontend/src/hooks/useParameter.tsx
+++ b/frontend/src/hooks/useParameter.tsx
@@ -1,4 +1,4 @@
-import { useContext, useSyncExternalStore } from "react";
+import { useCallback, useContext, useSyncExternalStore } from "react";
 import { ParameterValueType } from "../types/ExperimentMetadata";
 import { ParameterStoreContext } from "../contexts/ParameterStoreContext";
 
@@ -24,5 +24,12 @@ export function useParameter(
     () => store.get(key),
   );
 
-  return [value, (v: ParameterValueType) => store.set(key, v)];
+  const setValue = useCallback(
+    (v: ParameterValueType) => {
+      store.set(key, v);
+    },
+    [store, key],
+  );
+
+  return [value, setValue];
 }

--- a/frontend/src/hooks/useScanContext.tsx
+++ b/frontend/src/hooks/useScanContext.tsx
@@ -2,17 +2,19 @@ import { useContext } from "react";
 import { ScanContext } from "../contexts/ScanContext";
 import { defaultScanInfoState } from "./useScanInfoState";
 
+const defaultScanContext = {
+  scanInfoState: defaultScanInfoState,
+  dispatchScanInfoStateUpdate: () => {},
+  menuAnchor: { mouseX: null, mouseY: null },
+  handleRightClick: () => {},
+  handleCloseMenu: () => {},
+  scannedParamKeys: [],
+};
+
 export const useScanContext = () => {
   const context = useContext(ScanContext);
   if (!context) {
-    return {
-      scanInfoState: defaultScanInfoState,
-      dispatchScanInfoStateUpdate: () => {},
-      menuAnchor: { mouseX: null, mouseY: null },
-      handleRightClick: () => {},
-      handleCloseMenu: () => {},
-      scannedParamKeys: [],
-    };
+    return defaultScanContext;
   }
   return context;
 };


### PR DESCRIPTION
- Memoised setter function in useParameter with useCallback to keep a stable reference.
- Introduced stable default values in useScanContext to avoid new array/object creation.
- Wrapped Combobox with React.memo to prevent re-render when props are unchanged.
- Overall reduces render churn and maybe improves UI responsiveness.