### PR TITLE
Fix: optional chaining parameter options

### DIFF
--- a/frontend/src/components/parameterComponents/Combobox.tsx
+++ b/frontend/src/components/parameterComponents/Combobox.tsx
@@ -8,7 +8,7 @@ import {
   Typography,
 } from "@mui/material";
 import { HelpButton } from "../HelpButtonComponent";
-import React, { useCallback, useEffect } from "react";
+import React, { useCallback } from "react";
 
 interface ComboboxProps {
   id: string;

--- a/frontend/src/components/scanInterface/ParameterCard.tsx
+++ b/frontend/src/components/scanInterface/ParameterCard.tsx
@@ -176,11 +176,6 @@ export const ParameterCard = ({
           value={param.id}
           title={param.id}
           onChange={(e) => {
-            console.log({
-              id: e.target.value,
-              min: parameterOptions[e.target.value].min,
-              max: parameterOptions[e.target.value].max,
-            });
             dispatchScanInfoStateUpdate({
               type: "UPDATE_PARAMETER",
               index,

--- a/frontend/src/components/scanInterface/ParameterCard.tsx
+++ b/frontend/src/components/scanInterface/ParameterCard.tsx
@@ -227,8 +227,8 @@ export const ParameterCard = ({
           slotProps={{
             input: {
               inputProps: {
-                min: parameterOptions[param.id].min,
-                max: parameterOptions[param.id].max,
+                min: parameterOptions[param.id]?.min,
+                max: parameterOptions[param.id]?.max,
               },
             },
           }}
@@ -262,8 +262,8 @@ export const ParameterCard = ({
           slotProps={{
             input: {
               inputProps: {
-                min: parameterOptions[param.id].min,
-                max: parameterOptions[param.id].max,
+                min: parameterOptions[param.id]?.min,
+                max: parameterOptions[param.id]?.max,
               },
             },
           }}


### PR DESCRIPTION
Added optional chaining (?.) for min/max access in ParameterCard to avoid runtime errors when parameterOptions[param.id] is missing.
Also removes unused imports and console.log statements.