### PR TITLE
refactor: extract parameter store logic into useParameterStore hook

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,33 +5,23 @@ import { Outlet } from "react-router";
 import { ReactRouterAppProvider } from "@toolpad/core/react-router";
 import type { Navigation } from "@toolpad/core/AppProvider";
 import { NotificationsProvider } from "@toolpad/core/useNotifications";
-import { useEffect, useReducer, useRef, useState } from "react";
-import { runMethod, socket } from "./socket";
+import { useEffect, useReducer, useState } from "react";
+import { runMethod } from "./socket";
 import { deserialize } from "./utils/deserializer";
 import { SerializedObject } from "./types/SerializedObject";
 import { ExperimentsContext } from "./contexts/ExperimentsContext";
-import {
-  ExperimentDict,
-  ParameterMetadata,
-  ParameterValueType,
-} from "./types/ExperimentMetadata";
+import { ExperimentDict, ParameterMetadata } from "./types/ExperimentMetadata";
 import { SvgIcon } from "@mui/material";
 import SettingsIcon from "@mui/icons-material/Settings";
 import { ParameterDisplayGroupsContext } from "./contexts/ParameterDisplayGroupsContext";
 import { reducer, JobsContext } from "./contexts/JobsContext";
 import { ParameterStoreProvider } from "./contexts/ParameterStoreContext";
 import { useJobsSync } from "./hooks/useJobsSync";
-import { createParameterStore } from "./stores/parmeterStore";
 import { deviceInfoReducer, DeviceInfoContext } from "./contexts/DeviceInfoContext";
 import { useDevicesSync } from "./hooks/useDevicesSync";
 import { DeviceStateContext, deviceStateReducer } from "./contexts/DeviceStateContext";
 import logo from "./assets/logo.png";
 import { useParameterStore } from "./hooks/useParameterStore";
-
-interface ParameterUpdate {
-  id: string;
-  value: ParameterValueType;
-}
 
 const NAVIGATION: Navigation = [
   {

--- a/frontend/src/hooks/useParameterStore.tsx
+++ b/frontend/src/hooks/useParameterStore.tsx
@@ -1,0 +1,55 @@
+import { useEffect, useRef } from "react";
+import { runMethod, socket } from "../socket";
+import { deserialize } from "../utils/deserializer";
+import { SerializedObject } from "../types/SerializedObject";
+import { createParameterStore } from "../stores/parmeterStore";
+import { ParameterValueType } from "../types/ExperimentMetadata";
+
+interface ParameterUpdate {
+  id: string;
+  value: ParameterValueType;
+}
+
+/**
+ * React hook that synchronizes the local parameter store with the backend.
+ *
+ * This hook:
+ * - Initializes a new parameter store (stable across renders).
+ * - Fetches the full parameter set from the backend (`parameters.get_all_parameters`)
+ *   and seeds the store with it.
+ * - Subscribes to `parameter.update` events over the socket to update individual values.
+ * - Cleans up its socket listener when the component unmounts.
+ *
+ * @returns A stable reference to the parameter store instance.
+ */
+export function useParameterStore() {
+  const parameterStore = useRef(createParameterStore()).current;
+
+  useEffect(() => {
+    const handleUpdate = ({ id, value }: ParameterUpdate) => {
+      parameterStore.set(id, value);
+    };
+
+    socket.on("parameter.update", handleUpdate);
+
+    runMethod("parameters.get_all_parameters", [], {}, (ack) => {
+      try {
+        const parameterMapping = deserialize(ack as SerializedObject) as Record<
+          string,
+          ParameterValueType
+        >;
+        if (parameterMapping && typeof parameterMapping === "object") {
+          parameterStore.bulkSet(parameterMapping);
+        }
+      } catch (err) {
+        console.error("Failed to initialize parameter store:", err);
+      }
+    });
+
+    return () => {
+      socket.off("parameter.update", handleUpdate);
+    };
+  }, [parameterStore]);
+
+  return parameterStore;
+}


### PR DESCRIPTION
- Removed inline parameterStore setup from App.tsx.
- Introduced dedicated useParameterStore hook to encapsulate:
  - Initial fetch of all parameters from backend.
  - Subscription to parameter.update socket events.
  - Automatic cleanup on unmount.
- Simplifies App.tsx and centralises parameter store logic.