### PR TITLE
ParametersRepository: adds namespace and parameter_group tags to Influx

### DIFF
--- a/src/icon/server/data_access/db_context/influxdb_v1.py
+++ b/src/icon/server/data_access/db_context/influxdb_v1.py
@@ -4,9 +4,9 @@ import logging
 import sys
 from typing import TYPE_CHECKING, Any, Literal
 
+import influxdb
 import requests
 
-import influxdb
 from icon.config.config import get_config
 
 if TYPE_CHECKING:

--- a/src/icon/server/data_access/repositories/parameters_repository.py
+++ b/src/icon/server/data_access/repositories/parameters_repository.py
@@ -23,19 +23,12 @@ class NotInitialisedError(Exception):
 
 def get_specifiers_from_parameter_identifier(
     parameter_identifier: str,
-) -> tuple[str, str, dict[str, str]]:
+) -> dict[str, str]:
     # Regex pattern to match key='value' pairs, including namespace and parameter_group
     pattern = re.compile(r"(\w+)='([^']*)'")
     matches = pattern.findall(parameter_identifier)
 
-    # Construct the dictionary from the matched key-value pairs
-    specifiers = dict(matches)
-
-    # Pop namespace and parameter_group
-    namespace = specifiers.pop("namespace")
-    parameter_group = specifiers.pop("parameter_group")
-
-    return namespace, parameter_group, specifiers
+    return dict(matches)
 
 
 class ParametersRepository:
@@ -155,12 +148,10 @@ class ParametersRepository:
         records: list[dict[str, Any]] = []
 
         for parameter_id, value in parameter_mapping.items():
-            _, _, specifiers = get_specifiers_from_parameter_identifier(parameter_id)
-
             records.append(
                 {
                     "measurement": get_config().databases.influxdbv1.measurement,
-                    "tags": specifiers,
+                    "tags": get_specifiers_from_parameter_identifier(parameter_id),
                     "fields": {parameter_id: value},
                 }
             )


### PR DESCRIPTION
Changes the `get_specifiers_from_parameter_identifier` method to not remove the `namespace` and `parameter_group` keys from the specifiers. As I need the namespace tag to query parameters by namespace (`ParametersRepository.get_influxdbv1_parameters`), I have to add it to the tags.

 The function was written like that when I was still using a different scheme and I apparently didn't notice this issue.