### PR TITLE
feat(config): set sensible defaults for SQLite file and results dir

### DIFF
--- a/src/icon/config/v1.py
+++ b/src/icon/config/v1.py
@@ -9,7 +9,7 @@ class HealthCheckConfig(BaseModel):
 
 
 class DataConfiguration(BaseModel):
-    results_dir: str = str(Path(__file__).parent.parent.parent.parent / "output")
+    results_dir: str = str(Path.cwd() / "output")
 
 
 class ExperimentLibraryConfigV1(BaseModel):
@@ -31,7 +31,7 @@ class InfluxDBv1Config(BaseModel):
 
 
 class SQLiteConfig(BaseModel):
-    file: str | None = None
+    file: str = str(Path.cwd() / "icon.db")
 
 
 class DatabaseConfig(BaseModel):

--- a/src/icon/server/data_access/db_context/sqlite/engine.py
+++ b/src/icon/server/data_access/db_context/sqlite/engine.py
@@ -5,18 +5,12 @@ import sqlalchemy
 from icon.config.config import get_config
 
 sqlite_file = get_config().databases.sqlite.file
-if sqlite_file is None:
-    raise RuntimeError(
-        "The databases.sqlite.file option in your configuration is set to None. You "
-        "have to specify a file path for the sqlite database, e.g. "
-        "/var/lib/icon/sqlite.db"
-    )
 
 sqlite_file_path = pathlib.Path(sqlite_file)
 if not sqlite_file_path.parent.exists():
     sqlite_file_path.parent.mkdir()
 
 
-SQLITE_URL = f"sqlite:///{get_config().databases.sqlite.file}"
+SQLITE_URL = f"sqlite:///{sqlite_file}"
 
 engine = sqlalchemy.create_engine(SQLITE_URL, echo=False)


### PR DESCRIPTION
- SQLiteConfig.file now defaults to `icon.db` in the current working directory
- DataConfiguration.results_dir now defaults to `output` in the current working directory
- Replaces previous `__file__`-based defaults, which were not reliable when using PyInstaller