### PR TITLE
Minor restructure of Shared Resource Manager

### DIFF
--- a/src/icon/server/__main__.py
+++ b/src/icon/server/__main__.py
@@ -63,9 +63,7 @@ def start_server() -> None:
 
     SRM.start_srm()
 
-    scheduler = Scheduler(
-        pre_processing_queue=SRM.pre_processing_queue
-    )
+    scheduler = Scheduler(pre_processing_queue=SRM.pre_processing_queue)
     scheduler.start()
     config = get_config()
 

--- a/src/icon/server/__main__.py
+++ b/src/icon/server/__main__.py
@@ -12,6 +12,7 @@ from icon.logging import setup_logging
 from icon.server.data_access.reconfigurable_experiment_library_client import (
     ReconfigurableExperimentLibraryClient,
 )
+from icon.server.shared_resource_manager import SRM
 
 if TYPE_CHECKING:
     from icon.server.post_processing.task import PostProcessingTask
@@ -60,8 +61,10 @@ def start_server() -> None:
     patch_serialization_methods()
     run_migrations()
 
+    SRM.start_srm()
+
     scheduler = Scheduler(
-        pre_processing_queue=icon.server.shared_resource_manager.pre_processing_queue
+        pre_processing_queue=SRM.pre_processing_queue
     )
     scheduler.start()
     config = get_config()
@@ -76,10 +79,10 @@ def start_server() -> None:
         PreProcessingWorker(
             experiment_library_client=exp_lib_client,
             worker_number=i,
-            hardware_processing_queue=icon.server.shared_resource_manager.hardware_processing_queue,
-            pre_processing_queue=icon.server.shared_resource_manager.pre_processing_queue,
+            hardware_processing_queue=SRM.hardware_processing_queue,
+            pre_processing_queue=SRM.pre_processing_queue,
             update_queue=queue,
-            manager=icon.server.shared_resource_manager.manager,
+            manager=SRM,
         ).start()
 
     post_processing_queue: multiprocessing.Queue[PostProcessingTask] = (
@@ -87,9 +90,9 @@ def start_server() -> None:
     )
 
     hardware_processing_worker = HardwareProcessingWorker(
-        hardware_processing_queue=icon.server.shared_resource_manager.hardware_processing_queue,
+        hardware_processing_queue=SRM.hardware_processing_queue,
         post_processing_queue=post_processing_queue,
-        manager=icon.server.shared_resource_manager.manager,
+        manager=SRM,
     )
     hardware_processing_worker.start()
 

--- a/src/icon/server/api/parameters_controller.py
+++ b/src/icon/server/api/parameters_controller.py
@@ -132,10 +132,10 @@ class ParametersController(pydase.DataService):
         the shared resource manager, and marks the `ParametersRepository` as
         initialized.
         """
-        icon.server.shared_resource_manager.parameters_dict.update(
+        icon.server.shared_resource_manager.SRM.parameters_dict.update(
             ParametersRepository.get_influxdb_parameters()
         )
         ParametersRepository.initialize(
-            shared_parameters=icon.server.shared_resource_manager.parameters_dict
+            shared_parameters=icon.server.shared_resource_manager.SRM.parameters_dict
         )
         logger.info("ParametersRepository successfully initialised.")

--- a/src/icon/server/shared_resource_manager.py
+++ b/src/icon/server/shared_resource_manager.py
@@ -35,11 +35,13 @@ class SharedResourceManager(SyncManager):
         self.start(initializer=self.initializer)
 
         self.pre_processing_queue = self.PriorityQueue()
-        self.hardware_processing_queue = self.PriorityQueue(maxsize=HARDWARE_PROCESSING_QUEUE_MAX_SIZE)
+        self.hardware_processing_queue = self.PriorityQueue(
+            maxsize=HARDWARE_PROCESSING_QUEUE_MAX_SIZE
+        )
         self.parameters_dict = self.dict()
-
 
     def initializer(self) -> None:
         logger.info("Shared resource manager started")
+
 
 SRM = SharedResourceManager()

--- a/src/icon/server/shared_resource_manager.py
+++ b/src/icon/server/shared_resource_manager.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import queue
 from multiprocessing.managers import DictProxy, SyncManager
 from typing import TYPE_CHECKING, Any
@@ -9,18 +10,36 @@ if TYPE_CHECKING:
     from icon.server.hardware_processing.task import HardwareProcessingTask
     from icon.server.pre_processing.task import PreProcessingTask
 
+logger = logging.getLogger(__name__)
+
+HARDWARE_PROCESSING_QUEUE_MAX_SIZE = 10
+"""Maximum number of tasks allowed in the hardware processing queue before it blocks.
+This avoids excessive queue growth during long running real-time scans."""
+
 
 class SharedResourceManager(SyncManager):
+    """Multiprocessing SyncManager that owns shared queues and dicts used across multiple server processes."""
+
     PriorityQueue: type[queue.PriorityQueue[Any]]
 
+    pre_processing_queue: queue.PriorityQueue[PreProcessingTask]
+    hardware_processing_queue: queue.PriorityQueue[HardwareProcessingTask]
+    parameters_dict: DictProxy[str, DatabaseValueType]
 
-manager = SharedResourceManager()
-manager.register("PriorityQueue", queue.PriorityQueue)
-manager.start()
+    def __init__(self) -> None:
+        super().__init__()
+        self.register("PriorityQueue", queue.PriorityQueue)
 
-# Create shared priority queues
-pre_processing_queue: queue.PriorityQueue[PreProcessingTask] = manager.PriorityQueue()
-hardware_processing_queue: queue.PriorityQueue[HardwareProcessingTask] = (
-    manager.PriorityQueue()
-)
-parameters_dict: DictProxy[str, DatabaseValueType] = manager.dict()
+    def start_srm(self) -> None:
+        """Start the manager server process and initialize shared resources."""
+        self.start(initializer=self.initializer)
+
+        self.pre_processing_queue = self.PriorityQueue()
+        self.hardware_processing_queue = self.PriorityQueue(maxsize=HARDWARE_PROCESSING_QUEUE_MAX_SIZE)
+        self.parameters_dict = self.dict()
+
+
+    def initializer(self) -> None:
+        logger.info("Shared resource manager started")
+
+SRM = SharedResourceManager()


### PR DESCRIPTION
This change encapsulates the shared resources into the SharedResourceManager singleton. 
Changes:
* Instead of starting the SyncManager process at import time, an explicit start method has to be called during a server startup sequence. 
* The hardware_processing_queue is limited to 10 to avoid excessive growth in the real-time scan operating mode

Fixes:
* Fixes #71 by avoiding the creation of the SyncManager server process at import time
* Fixes #88 by limiting the hardware_processing_queue size. When maximum size is reached, the PreProcessing workers will block on `put` and therefore synchronize its production rate to the consumption rate of the HardwareProcessingWorker.

Side effects:
* Limiting the hardware_processing_queue size may lead to situations where the submission of higher priority jobs into the queue will block due to the queue being full with lower priority items. Assuming a constant consumption rate at the HardwareProcessingWorker and no starvation of a single PreProcessingWorker in competing for queue insertion, the high priority job will make it with some acceptable delay. However, this should be looked at in a future revision.
