### PR TITLE
fix: show 2 decimal places on 2D colorbar for probability data

### DIFF
--- a/frontend/src/components/ResultChannelPlot.tsx
+++ b/frontend/src/components/ResultChannelPlot.tsx
@@ -85,7 +85,7 @@ function updateVisualMap(chart: ECharts, selectedChannelName: string | undefined
   });
 
   chart.setOption({
-    visualMap: [{ min, max }],
+    visualMap: [{ min, max, ...(max <= 1 && { formatter: (v: number) => v.toFixed(2) }) }],
   });
 }
 


### PR DESCRIPTION
When the data maximum is ≤ 1 (e.g. probabilities), ECharts was rounding colorbar tick labels to integers, collapsing a range like 0.33–0.70 into "0" and "1". Now the formatter switches to two decimal places for that case, while counts (> 1) keep the default integer labels. This distinguishes the plotting for thresholded vs non-tresholded plots. 