### PR TITLE
19 add support for retaking data points

### DIFF
--- a/frontend/src/components/JobView.tsx
+++ b/frontend/src/components/JobView.tsx
@@ -28,6 +28,7 @@ import { updateJobParams } from "../utils/updateJobParams";
 import { cancelJob } from "../utils/cancelJob";
 import { pauseJob } from "../utils/pauseJob";
 import { resumeJob } from "../utils/resumeJob";
+import { retakeDataPoints } from "../utils/retakeDataPoints";
 import HistogramPlot from "./jobView/HistogramPlot";
 import FitPanel from "./jobView/FitPanel";
 
@@ -250,6 +251,36 @@ export const JobView = ({
                       }}
                     >
                       Pause
+                    </Button>
+                    <Button
+                      variant="contained"
+                      color="primary"
+                      disabled={
+                        jobRunInfo?.status !== JobRunStatus.PAUSED ||
+                        Boolean(experimentData?.realtime_scan)
+                      }
+                      size="small"
+                      sx={{ ml: 1 }}
+                      onClick={() => {
+                        if (jobId) retakeDataPoints(Number(jobId), 1);
+                      }}
+                    >
+                      Retake 1 data point
+                    </Button>
+                    <Button
+                      variant="contained"
+                      color="primary"
+                      disabled={
+                        jobRunInfo?.status !== JobRunStatus.PAUSED ||
+                        Boolean(experimentData?.realtime_scan)
+                      }
+                      size="small"
+                      sx={{ ml: 1 }}
+                      onClick={() => {
+                        if (jobId) retakeDataPoints(Number(jobId), 10);
+                      }}
+                    >
+                      Retake 10 data points
                     </Button>
                     <Button
                       variant="contained"

--- a/frontend/src/hooks/useExperimentData.tsx
+++ b/frontend/src/hooks/useExperimentData.tsx
@@ -20,6 +20,7 @@ const emptyExperimentData: ExperimentData = {
   vector_channels: {},
   scan_parameters: {},
   json_sequences: [],
+  realtime_scan: false,
   parameters: {},
   total_data_points: 0,
   fits: {},

--- a/frontend/src/types/ExperimentData.ts
+++ b/frontend/src/types/ExperimentData.ts
@@ -47,6 +47,7 @@ export interface ExperimentData {
   vector_channels: Record<string, Record<string, number[]>>;
   scan_parameters: Record<string, Record<string, number | boolean | string>>;
   json_sequences: [number, string][];
+  realtime_scan: boolean;
   parameters: Record<string, ParameterValue>;
   total_data_points: number;
   fits: Record<string, FitResult>;

--- a/frontend/src/utils/retakeDataPoints.ts
+++ b/frontend/src/utils/retakeDataPoints.ts
@@ -1,0 +1,14 @@
+import { runMethod } from "../socket";
+
+export const retakeDataPoints = (
+  jobId: number,
+  noDataPoints: number,
+  callback?: (ack: unknown) => void,
+) => {
+  runMethod(
+    "scans.retake_data_points",
+    [],
+    { job_id: jobId, no_data_points: noDataPoints },
+    callback,
+  );
+};

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,6 +125,7 @@ ignore = [
 [tool.ruff.lint.per-file-ignores]
 "tests/**" = [
     "S101",     # assert
+    "PLR2004",  # magic value used in comparison (expected values in tests)
 ]
 
 [tool.ruff.lint.mccabe]

--- a/src/icon/server/api/scans_controller.py
+++ b/src/icon/server/api/scans_controller.py
@@ -5,6 +5,9 @@ from typing import TYPE_CHECKING
 
 import pydase
 
+from icon.server.data_access.models.enums import JobRunStatus
+from icon.server.data_access.repositories.job_run_repository import JobRunRepository
+
 if TYPE_CHECKING:
     import multiprocessing
 
@@ -39,5 +42,32 @@ class ScansController(pydase.DataService):
                 {
                     "event": "update_parameters",
                     "job_id": job_id,
+                }
+            )
+
+    async def retake_data_points(self, *, job_id: int, no_data_points: int) -> None:
+        """Triggers a 'retake_data_points' event for the given job ID.
+
+        The job run must be paused. The last `no_data_points` data points are moved
+        into invalid datasets in the HDF5 file and re-queued for re-acquisition.
+
+        Args:
+            job_id: ID of the job whose last data points should be retaken.
+            no_data_points: Number of data points to be retaken.
+
+        Raises:
+            RuntimeError: If the job run is not paused.
+        """
+        job_run = JobRunRepository.get_run_by_job_id(job_id=job_id)
+
+        if job_run.status != JobRunStatus.PAUSED:
+            raise RuntimeError("Cannot retake data points when the job is not paused")
+
+        for pre_processing_update_queue in self._pre_processing_update_queues:
+            pre_processing_update_queue.put(
+                {
+                    "event": "retake_data_points",
+                    "job_id": job_id,
+                    "no_data_points": no_data_points,
                 }
             )

--- a/src/icon/server/data_access/repositories/experiment_data_repository.py
+++ b/src/icon/server/data_access/repositories/experiment_data_repository.py
@@ -335,7 +335,7 @@ def write_vector_channels_to_datasets(
 
 
 def _append_invalid_indices(h5file: h5py.File, indices: list[int]) -> int:
-    """Append original data-point indices to the 'invalid_indices' dataset.
+    """Append original data-point indices to the 'invalid/indices' dataset.
 
     Args:
         h5file: Open HDF5 file handle.
@@ -345,11 +345,11 @@ def _append_invalid_indices(h5file: h5py.File, indices: list[int]) -> int:
         The append position of the first new entry, used to align the
         per-channel invalid datasets with this batch.
     """
-    if "invalid_indices" in h5file:
-        dataset = cast("h5py.Dataset", h5file["invalid_indices"])
+    if "invalid/indices" in h5file:
+        dataset = cast("h5py.Dataset", h5file["invalid/indices"])
     else:
         dataset = h5file.create_dataset(
-            "invalid_indices",
+            "invalid/indices",
             shape=(0,),
             maxshape=(None,),
             chunks=True,
@@ -362,7 +362,7 @@ def _append_invalid_indices(h5file: h5py.File, indices: list[int]) -> int:
 
 
 def _move_rows_to_invalid(h5file: h5py.File, name: str, start: int, count: int) -> None:
-    """Move rows ``[start:start + count]`` of a dataset into 'invalid_<name>'.
+    """Move rows ``[start:start + count]`` of a dataset into 'invalid/<name>'.
 
     Appends the rows to the (create-if-absent) invalid dataset and shrinks the
     live dataset. Works for both the 2D ``scan_parameters`` and the 1D
@@ -379,7 +379,7 @@ def _move_rows_to_invalid(h5file: h5py.File, name: str, start: int, count: int) 
         return
     source = cast("h5py.Dataset", source)
     rows = source[start : start + count]
-    invalid_name = f"invalid_{name}"
+    invalid_name = f"invalid/{name}"
     if invalid_name in h5file:
         dataset = cast("h5py.Dataset", h5file[invalid_name])
     else:
@@ -399,7 +399,7 @@ def _move_rows_to_invalid(h5file: h5py.File, name: str, start: int, count: int) 
 
 
 def _move_shot_channels_to_invalid(h5file: h5py.File, start: int, count: int) -> None:
-    """Move shot-channel rows ``[start:start + count]`` into 'invalid_shot_channels'.
+    """Move shot-channel rows ``[start:start + count]`` into 'invalid/shot_channels'.
 
     Args:
         h5file: Open HDF5 file handle.
@@ -409,7 +409,7 @@ def _move_shot_channels_to_invalid(h5file: h5py.File, start: int, count: int) ->
     shot_group = h5file.get("shot_channels")
     if shot_group is None:
         return
-    invalid_group = h5file.require_group("invalid_shot_channels")
+    invalid_group = h5file.require_group("invalid/shot_channels")
     for channel_name, channel in cast("h5py.Group", shot_group).items():
         source = cast("h5py.Dataset", channel)
         rows = source[start : start + count]
@@ -434,22 +434,22 @@ def _move_shot_channels_to_invalid(h5file: h5py.File, start: int, count: int) ->
 def _move_vector_channels_to_invalid(
     h5file: h5py.File, indices: list[int], base: int
 ) -> None:
-    """Move per-index vector datasets into 'invalid_vector_channels'.
+    """Move per-index vector datasets into 'invalid/vector_channels'.
 
     Each moved dataset is renamed to its append position (``base + offset``),
-    aligning it with ``invalid_indices`` and avoiding name collisions across
+    aligning it with ``invalid/indices`` and avoiding name collisions across
     repeated retakes. Deleting the live dataset frees its name so re-acquisition
     recreates it.
 
     Args:
         h5file: Open HDF5 file handle.
         indices: Original indices of the data points being invalidated.
-        base: Append position of the first moved entry in ``invalid_indices``.
+        base: Append position of the first moved entry in ``invalid/indices``.
     """
     vector_group = h5file.get("vector_channels")
     if vector_group is None:
         return
-    invalid_group = h5file.require_group("invalid_vector_channels")
+    invalid_group = h5file.require_group("invalid/vector_channels")
     for channel_name, channel in cast("h5py.Group", vector_group).items():
         channel_group = cast("h5py.Group", channel)
         invalid_channel_group = invalid_group.require_group(channel_name)
@@ -465,12 +465,12 @@ def _move_vector_channels_to_invalid(
 def _move_last_n_data_points_to_invalid(
     h5file: h5py.File, no_data_points: int
 ) -> list[int]:
-    """Move the last ``no_data_points`` data points into 'invalid_*' datasets.
+    """Move the last ``no_data_points`` data points into the 'invalid/' group.
 
     The live datasets shrink so the points can be re-acquired at their original
     indices, and ``number_of_data_points`` is decremented accordingly. The moved
-    data is preserved under ``invalid_indices`` and the matching ``invalid_*``
-    datasets/groups.
+    data is preserved under the ``invalid/`` group, tagged with the original
+    data-point index in ``invalid/indices``.
 
     Args:
         h5file: Open HDF5 file handle.
@@ -750,10 +750,10 @@ class ExperimentDataRepository:
 
     @staticmethod
     def mark_data_points_as_invalid(*, job_id: int, no_data_points: int) -> list[int]:
-        """Move the last ``no_data_points`` data points of a job into invalid datasets.
+        """Move the last ``no_data_points`` data points of a job into ``invalid/``.
 
-        The bad data is preserved under ``invalid_*`` datasets (tagged with the
-        original data-point index in ``invalid_indices``) and removed from the live
+        The bad data is preserved under the ``invalid/`` group (tagged with the
+        original data-point index in ``invalid/indices``) and removed from the live
         datasets so the points can be re-acquired at their original indices.
 
         Args:

--- a/src/icon/server/data_access/repositories/experiment_data_repository.py
+++ b/src/icon/server/data_access/repositories/experiment_data_repository.py
@@ -334,6 +334,169 @@ def write_vector_channels_to_datasets(
             )
 
 
+def _append_invalid_indices(h5file: h5py.File, indices: list[int]) -> int:
+    """Append original data-point indices to the 'invalid_indices' dataset.
+
+    Args:
+        h5file: Open HDF5 file handle.
+        indices: Original indices of the data points being invalidated.
+
+    Returns:
+        The append position of the first new entry, used to align the
+        per-channel invalid datasets with this batch.
+    """
+    if "invalid_indices" in h5file:
+        dataset = cast("h5py.Dataset", h5file["invalid_indices"])
+    else:
+        dataset = h5file.create_dataset(
+            "invalid_indices",
+            shape=(0,),
+            maxshape=(None,),
+            chunks=True,
+            dtype=np.int64,
+        )
+    base = int(dataset.shape[0])
+    dataset.resize(base + len(indices), axis=0)
+    dataset[base:] = indices
+    return base
+
+
+def _move_rows_to_invalid(h5file: h5py.File, name: str, start: int, count: int) -> None:
+    """Move rows ``[start:start + count]`` of a dataset into 'invalid_<name>'.
+
+    Appends the rows to the (create-if-absent) invalid dataset and shrinks the
+    live dataset. Works for both the 2D ``scan_parameters`` and the 1D
+    ``result_channels`` datasets. No-op if the source dataset is absent.
+
+    Args:
+        h5file: Open HDF5 file handle.
+        name: Name of the live dataset to move rows out of.
+        start: Index of the first row to move.
+        count: Number of rows to move.
+    """
+    source = h5file.get(name)
+    if source is None:
+        return
+    source = cast("h5py.Dataset", source)
+    rows = source[start : start + count]
+    invalid_name = f"invalid_{name}"
+    if invalid_name in h5file:
+        dataset = cast("h5py.Dataset", h5file[invalid_name])
+    else:
+        dataset = h5file.create_dataset(
+            invalid_name,
+            shape=(0, *source.shape[1:]),
+            maxshape=(None, *source.shape[1:]),
+            chunks=True,
+            dtype=source.dtype,
+            compression="gzip",
+            compression_opts=9,
+        )
+    base = int(dataset.shape[0])
+    dataset.resize(base + count, axis=0)
+    dataset[base:] = rows
+    source.resize(start, axis=0)
+
+
+def _move_shot_channels_to_invalid(h5file: h5py.File, start: int, count: int) -> None:
+    """Move shot-channel rows ``[start:start + count]`` into 'invalid_shot_channels'.
+
+    Args:
+        h5file: Open HDF5 file handle.
+        start: Index of the first row to move.
+        count: Number of rows to move.
+    """
+    shot_group = h5file.get("shot_channels")
+    if shot_group is None:
+        return
+    invalid_group = h5file.require_group("invalid_shot_channels")
+    for channel_name, channel in cast("h5py.Group", shot_group).items():
+        source = cast("h5py.Dataset", channel)
+        rows = source[start : start + count]
+        if channel_name in invalid_group:
+            dataset = cast("h5py.Dataset", invalid_group[channel_name])
+        else:
+            dataset = invalid_group.create_dataset(
+                channel_name,
+                shape=(0, source.shape[1]),
+                maxshape=(None, source.shape[1]),
+                chunks=True,
+                dtype=source.dtype,
+                compression="gzip",
+                compression_opts=9,
+            )
+        base = int(dataset.shape[0])
+        dataset.resize(base + count, axis=0)
+        dataset[base:] = rows
+        source.resize(start, axis=0)
+
+
+def _move_vector_channels_to_invalid(
+    h5file: h5py.File, indices: list[int], base: int
+) -> None:
+    """Move per-index vector datasets into 'invalid_vector_channels'.
+
+    Each moved dataset is renamed to its append position (``base + offset``),
+    aligning it with ``invalid_indices`` and avoiding name collisions across
+    repeated retakes. Deleting the live dataset frees its name so re-acquisition
+    recreates it.
+
+    Args:
+        h5file: Open HDF5 file handle.
+        indices: Original indices of the data points being invalidated.
+        base: Append position of the first moved entry in ``invalid_indices``.
+    """
+    vector_group = h5file.get("vector_channels")
+    if vector_group is None:
+        return
+    invalid_group = h5file.require_group("invalid_vector_channels")
+    for channel_name, channel in cast("h5py.Group", vector_group).items():
+        channel_group = cast("h5py.Group", channel)
+        invalid_channel_group = invalid_group.require_group(channel_name)
+        for offset, index in enumerate(indices):
+            source_name = str(index)
+            if source_name in channel_group:
+                channel_group.copy(
+                    source_name, invalid_channel_group, name=str(base + offset)
+                )
+                del channel_group[source_name]
+
+
+def _move_last_n_data_points_to_invalid(
+    h5file: h5py.File, no_data_points: int
+) -> list[int]:
+    """Move the last ``no_data_points`` data points into 'invalid_*' datasets.
+
+    The live datasets shrink so the points can be re-acquired at their original
+    indices, and ``number_of_data_points`` is decremented accordingly. The moved
+    data is preserved under ``invalid_indices`` and the matching ``invalid_*``
+    datasets/groups.
+
+    Args:
+        h5file: Open HDF5 file handle.
+        no_data_points: Number of trailing data points to invalidate. Clamped to
+            the number of stored data points.
+
+    Returns:
+        The original indices of the invalidated data points (ascending).
+    """
+    total = int(h5file.attrs.get("number_of_data_points", 0))
+    count = min(no_data_points, total)
+    if count <= 0:
+        return []
+    start = total - count
+    moved_indices = list(range(start, total))
+
+    base = _append_invalid_indices(h5file, moved_indices)
+    _move_rows_to_invalid(h5file, "scan_parameters", start, count)
+    _move_rows_to_invalid(h5file, "result_channels", start, count)
+    _move_shot_channels_to_invalid(h5file, start, count)
+    _move_vector_channels_to_invalid(h5file, moved_indices, base)
+
+    h5file.attrs["number_of_data_points"] = start
+    return moved_indices
+
+
 class ExperimentDataRepository:
     """Repository for HDF5-based experiment data.
 
@@ -584,6 +747,27 @@ class ExperimentDataRepository:
                 },
             }
         )
+
+    @staticmethod
+    def mark_data_points_as_invalid(*, job_id: int, no_data_points: int) -> list[int]:
+        """Move the last ``no_data_points`` data points of a job into invalid datasets.
+
+        The bad data is preserved under ``invalid_*`` datasets (tagged with the
+        original data-point index in ``invalid_indices``) and removed from the live
+        datasets so the points can be re-acquired at their original indices.
+
+        Args:
+            job_id: Job identifier.
+            no_data_points: Number of trailing data points to invalidate. Clamped to
+                the number of stored data points.
+
+        Returns:
+            The original indices of the invalidated data points (ascending).
+        """
+        filename = get_filename_by_job_id(job_id)
+        h5_path = Path(get_config().data.results_dir) / filename
+        with h5_open(h5_path, "a") as h5file:
+            return _move_last_n_data_points_to_invalid(h5file, no_data_points)
 
     @staticmethod
     def get_experiment_data_by_job_id(  # noqa: C901

--- a/src/icon/server/data_access/repositories/experiment_data_repository.py
+++ b/src/icon/server/data_access/repositories/experiment_data_repository.py
@@ -754,7 +754,9 @@ class ExperimentDataRepository:
 
         The bad data is preserved under the ``invalid/`` group (tagged with the
         original data-point index in ``invalid/indices``) and removed from the live
-        datasets so the points can be re-acquired at their original indices.
+        datasets so the points can be re-acquired at their original indices. Emits
+        an ``experiment_<job_id>_invalidated`` event with the moved indices so the
+        frontend can drop those points immediately.
 
         Args:
             job_id: Job identifier.
@@ -767,7 +769,16 @@ class ExperimentDataRepository:
         filename = get_filename_by_job_id(job_id)
         h5_path = Path(get_config().data.results_dir) / filename
         with h5_open(h5_path, "a") as h5file:
-            return _move_last_n_data_points_to_invalid(h5file, no_data_points)
+            moved_indices = _move_last_n_data_points_to_invalid(h5file, no_data_points)
+
+        if moved_indices:
+            emit_queue.put(
+                {
+                    "event": f"experiment_{job_id}_invalidated",
+                    "data": {"indices": moved_indices},
+                }
+            )
+        return moved_indices
 
     @staticmethod
     def get_experiment_data_by_job_id(  # noqa: C901

--- a/src/icon/server/hardware_processing/task.py
+++ b/src/icon/server/hardware_processing/task.py
@@ -9,6 +9,7 @@ import pydantic
 
 from icon.server.data_access.db_context.influxdb_v1 import DatabaseValueType
 from icon.server.pre_processing.task import PreProcessingTask
+from icon.server.utils.types import DataPointToProcess
 
 
 class HardwareProcessingTask(pydantic.BaseModel):
@@ -24,7 +25,7 @@ class HardwareProcessingTask(pydantic.BaseModel):
     created: datetime
     if TYPE_CHECKING:
         processed_data_points: Queue[HardwareProcessingTask]
-        data_points_to_process: Queue[tuple[int, dict[str, DatabaseValueType]]]
+        data_points_to_process: PriorityQueue[DataPointToProcess]
         outdated_tasks: PriorityQueue[HardwareProcessingTask]
     else:
         # must be Any as the queues are AutoProxy instances, which I didn't figure out

--- a/src/icon/server/pre_processing/worker.py
+++ b/src/icon/server/pre_processing/worker.py
@@ -36,6 +36,7 @@ from icon.server.data_access.repositories.parameters_repository import (
 from icon.server.fitting.auto_fit import try_auto_fit
 from icon.server.hardware_processing.task import HardwareProcessingTask
 from icon.server.utils.handle_keyboard_interrupt import handle_keyboard_interrupt
+from icon.server.utils.types import DataPointToProcess
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Iterator
@@ -174,9 +175,7 @@ class PreProcessingWorker(multiprocessing.Process):
         self._worker_number = worker_number
         self._manager = manager
         # Queues to communicate with the hardware worker:
-        self._data_points_to_process: queue.Queue[
-            tuple[int, dict[str, DatabaseValueType]]
-        ]
+        self._data_points_to_process: queue.PriorityQueue[DataPointToProcess]
         self._processed_data_points: queue.Queue[HardwareProcessingTask]
         self._parameter_dict: dict[str, DatabaseValueType] = {}
         self._outdated_tasks: queue.PriorityQueue[HardwareProcessingTask] = (
@@ -195,7 +194,7 @@ class PreProcessingWorker(multiprocessing.Process):
             while True:
                 pre_processing_task = self._queue.get()
 
-                self._data_points_to_process = self._manager.Queue()
+                self._data_points_to_process = self._manager.PriorityQueue()
                 self._processed_data_points = self._manager.Queue()
 
                 try:
@@ -436,8 +435,10 @@ class PreProcessingWorker(multiprocessing.Process):
                 "No scan combinations to process: check that 'repetitions' >= 1 "
                 "and all scan parameters have at least one scan value."
             )
-        for combination in enumerate(scan_parameter_value_combinations):
-            self._data_points_to_process.put(combination)
+        for index, combination in enumerate(scan_parameter_value_combinations):
+            self._data_points_to_process.put(
+                DataPointToProcess(index=index, scan_params=combination)
+            )
 
         while self._processed_data_points.qsize() != len(
             scan_parameter_value_combinations
@@ -448,7 +449,7 @@ class PreProcessingWorker(multiprocessing.Process):
             # TODO: this should probably be done with multiple workers to
             # speed up the preparation of JSONs
             try:
-                index, data_point = self._data_points_to_process.get(block=False)
+                next_data_point = self._data_points_to_process.get(block=False)
             except queue.Empty:
                 time.sleep(0.001)
                 continue
@@ -459,6 +460,8 @@ class PreProcessingWorker(multiprocessing.Process):
 
             if should_exit:
                 break
+
+            index, data_point = next_data_point.index, next_data_point.scan_params
 
             yield
             self._submit_task_to_hw_worker(
@@ -564,11 +567,18 @@ class PreProcessingWorker(multiprocessing.Process):
         for _ in itertools.repeat(None, *times):
             for combination in get_scan_combinations(pre_processing_task.job):
                 self._data_points_to_process.put(
-                    (next(realtime_scan_counter), combination)
+                    DataPointToProcess(
+                        index=next(realtime_scan_counter), scan_params=combination
+                    )
                 )
             if self._data_points_to_process.qsize() == 0:
-                self._data_points_to_process.put((next(realtime_scan_counter), {}))
-            for index, data_point in consume_queue(self._data_points_to_process):
+                self._data_points_to_process.put(
+                    DataPointToProcess(
+                        index=next(realtime_scan_counter), scan_params={}
+                    )
+                )
+            for next_data_point in consume_queue(self._data_points_to_process):
+                index, data_point = next_data_point.index, next_data_point.scan_params
                 if job_run_cancelled_or_failed(
                     job_id=pre_processing_task.job.id,
                 ):

--- a/src/icon/server/pre_processing/worker.py
+++ b/src/icon/server/pre_processing/worker.py
@@ -366,21 +366,19 @@ class PreProcessingWorker(multiprocessing.Process):
         self, pre_processing_task: PreProcessingTask, namespace: ExperimentIdentifier
     ) -> None:
         for parameter_update in consume_queue(self._update_queue):
-            event = parameter_update["event"]
-            job_id = parameter_update.get("job_id", None)
-            new_parameters = parameter_update.get("new_parameters", None)
-
-            if event == "update_parameters" and (
-                job_id is None or job_id == pre_processing_task.job.id
-            ):
-                self._update_parameter_dict(
-                    pre_processing_task, namespace, mode=ParamUpdateMode.ALL_UP_TO_DATE
-                )
-            elif event == "calibration" and new_parameters is not None:
+            if parameter_update["event"] == "update_parameters":
+                job_id = parameter_update.get("job_id", None)
+                if job_id is None or job_id == pre_processing_task.job.id:
+                    self._update_parameter_dict(
+                        pre_processing_task,
+                        namespace,
+                        mode=ParamUpdateMode.ALL_UP_TO_DATE,
+                    )
+            elif parameter_update["event"] == "calibration":
                 self._update_parameter_dict(
                     pre_processing_task,
                     namespace,
-                    new_parameters=new_parameters,
+                    new_parameters=parameter_update["new_parameters"],
                     mode=ParamUpdateMode.ONLY_NEW_PARAMETERS,
                 )
 

--- a/src/icon/server/utils/types.py
+++ b/src/icon/server/utils/types.py
@@ -3,7 +3,21 @@ from typing import Literal, NotRequired, TypedDict
 from icon.server.data_access.db_context.influxdb_v1 import DatabaseValueType
 
 
-class UpdateQueue(TypedDict):
-    event: Literal["update_parameters", "calibration"]
+class UpdateParametersEvent(TypedDict):
+    event: Literal["update_parameters"]
     job_id: NotRequired[int | None]
-    new_parameters: NotRequired[dict[str, DatabaseValueType]]
+
+
+class CalibrationEvent(TypedDict):
+    event: Literal["calibration"]
+    new_parameters: dict[str, DatabaseValueType]
+
+
+class RetakeDataPointsEvent(TypedDict):
+    event: Literal["retake_data_points"]
+    job_id: int
+    no_data_points: int
+
+
+UpdateQueue = UpdateParametersEvent | CalibrationEvent | RetakeDataPointsEvent
+"""Event placed on a pre-processing worker's update queue."""

--- a/src/icon/server/utils/types.py
+++ b/src/icon/server/utils/types.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 from typing import Literal, NotRequired, TypedDict
 
 from icon.server.data_access.db_context.influxdb_v1 import DatabaseValueType
@@ -21,3 +22,21 @@ class RetakeDataPointsEvent(TypedDict):
 
 UpdateQueue = UpdateParametersEvent | CalibrationEvent | RetakeDataPointsEvent
 """Event placed on a pre-processing worker's update queue."""
+
+
+@dataclass
+class DataPointToProcess:
+    """A data point queued for pre-processing.
+
+    Orders by ``index`` only, so a priority queue of data points dispenses them
+    in data-point order regardless of insertion order. Restricting the
+    comparison to the index (instead of comparing whole tuples) keeps the heap
+    from ever falling back to comparing the ``scan_params`` dicts, which do not
+    support ``<``.
+    """
+
+    index: int
+    scan_params: dict[str, DatabaseValueType]
+
+    def __lt__(self, other: "DataPointToProcess") -> bool:
+        return self.index < other.index

--- a/tests/server/data_access/test_experiment_data_repository.py
+++ b/tests/server/data_access/test_experiment_data_repository.py
@@ -1,0 +1,114 @@
+from pathlib import Path
+
+import h5py  # type: ignore
+import numpy as np
+
+from icon.server.data_access.repositories.experiment_data_repository import (
+    _move_last_n_data_points_to_invalid,
+    write_results_to_dataset,
+    write_scan_parameters_and_timestamp_to_dataset,
+    write_shot_channels_to_datasets,
+    write_vector_channels_to_datasets,
+)
+
+NUMBER_OF_SHOTS = 4
+
+
+def _write_data_points(h5file: h5py.File, count: int) -> None:
+    """Populate an HDF5 file with ``count`` simple data points (indices 0..count-1)."""
+    for index in range(count):
+        # `number_of_data_points` is the running total *before* this write.
+        write_scan_parameters_and_timestamp_to_dataset(
+            h5file=h5file,
+            data_point_index=index,
+            scan_params={"freq": float(index)},
+            timestamp=f"2024-01-01T00:00:{index:02d}.000000",
+            number_of_data_points=index,
+        )
+        write_results_to_dataset(
+            h5file=h5file,
+            data_point_index=index,
+            result_channels={"counts": float(index * 10)},
+            number_of_data_points=index,
+        )
+        write_shot_channels_to_datasets(
+            h5file=h5file,
+            data_point_index=index,
+            shot_channels={"shots": [index] * NUMBER_OF_SHOTS},
+            number_of_data_points=index,
+            number_of_shots=NUMBER_OF_SHOTS,
+        )
+        write_vector_channels_to_datasets(
+            h5file=h5file,
+            data_point_index=index,
+            vector_channels={"trace": [float(index), float(index + 1)]},
+        )
+    h5file.attrs["number_of_shots"] = NUMBER_OF_SHOTS
+    h5file.attrs["number_of_data_points"] = count
+
+
+def test_move_last_n_data_points_to_invalid(tmp_path: Path) -> None:
+    with h5py.File(tmp_path / "results.h5", "w") as h5file:
+        _write_data_points(h5file, count=5)
+
+        moved = _move_last_n_data_points_to_invalid(h5file, no_data_points=2)
+
+        assert moved == [3, 4]
+        assert h5file.attrs["number_of_data_points"] == 3
+
+        # Live datasets shrink by the number of moved points.
+        assert h5file["scan_parameters"].shape == (3, 1)
+        assert h5file["result_channels"].shape == (3,)
+        assert h5file["shot_channels/shots"].shape == (3, NUMBER_OF_SHOTS)
+        assert set(h5file["vector_channels/trace"].keys()) == {"0", "1", "2"}
+
+        # Invalid datasets hold the moved rows, tagged with their original index.
+        assert h5file["invalid_indices"][:].tolist() == [3, 4]
+        assert h5file["invalid_scan_parameters"]["freq"].flatten().tolist() == [
+            3.0,
+            4.0,
+        ]
+        assert h5file["invalid_result_channels"]["counts"].tolist() == [30.0, 40.0]
+        np.testing.assert_array_equal(
+            h5file["invalid_shot_channels/shots"][:],
+            np.array([[3] * NUMBER_OF_SHOTS, [4] * NUMBER_OF_SHOTS], dtype=np.float64),
+        )
+        # Vector datasets are renamed to their append position (aligned to indices).
+        assert set(h5file["invalid_vector_channels/trace"].keys()) == {"0", "1"}
+        assert h5file["invalid_vector_channels/trace/0"][:].tolist() == [3.0, 4.0]
+        assert h5file["invalid_vector_channels/trace/1"][:].tolist() == [4.0, 5.0]
+
+
+def test_move_last_n_data_points_appends_across_retakes(tmp_path: Path) -> None:
+    with h5py.File(tmp_path / "results.h5", "w") as h5file:
+        _write_data_points(h5file, count=5)
+
+        _move_last_n_data_points_to_invalid(h5file, no_data_points=2)
+        # A second retake of more points than remain is clamped to what is left.
+        moved = _move_last_n_data_points_to_invalid(h5file, no_data_points=10)
+
+        assert moved == [0, 1, 2]
+        assert h5file.attrs["number_of_data_points"] == 0
+        assert h5file["scan_parameters"].shape == (0, 1)
+
+        # Invalid datasets accumulate both batches.
+        assert h5file["invalid_indices"][:].tolist() == [3, 4, 0, 1, 2]
+        assert h5file["invalid_scan_parameters"].shape == (5, 1)
+        # Vector datasets from the second batch use append positions 2, 3, 4.
+        assert set(h5file["invalid_vector_channels/trace"].keys()) == {
+            "0",
+            "1",
+            "2",
+            "3",
+            "4",
+        }
+        assert h5file["invalid_vector_channels/trace/2"][:].tolist() == [0.0, 1.0]
+
+
+def test_move_last_n_data_points_noop_when_zero(tmp_path: Path) -> None:
+    with h5py.File(tmp_path / "results.h5", "w") as h5file:
+        _write_data_points(h5file, count=3)
+
+        assert _move_last_n_data_points_to_invalid(h5file, no_data_points=0) == []
+        assert h5file.attrs["number_of_data_points"] == 3
+        assert "invalid_indices" not in h5file

--- a/tests/server/data_access/test_experiment_data_repository.py
+++ b/tests/server/data_access/test_experiment_data_repository.py
@@ -63,20 +63,20 @@ def test_move_last_n_data_points_to_invalid(tmp_path: Path) -> None:
         assert set(h5file["vector_channels/trace"].keys()) == {"0", "1", "2"}
 
         # Invalid datasets hold the moved rows, tagged with their original index.
-        assert h5file["invalid_indices"][:].tolist() == [3, 4]
-        assert h5file["invalid_scan_parameters"]["freq"].flatten().tolist() == [
+        assert h5file["invalid/indices"][:].tolist() == [3, 4]
+        assert h5file["invalid/scan_parameters"]["freq"].flatten().tolist() == [
             3.0,
             4.0,
         ]
-        assert h5file["invalid_result_channels"]["counts"].tolist() == [30.0, 40.0]
+        assert h5file["invalid/result_channels"]["counts"].tolist() == [30.0, 40.0]
         np.testing.assert_array_equal(
-            h5file["invalid_shot_channels/shots"][:],
+            h5file["invalid/shot_channels/shots"][:],
             np.array([[3] * NUMBER_OF_SHOTS, [4] * NUMBER_OF_SHOTS], dtype=np.float64),
         )
         # Vector datasets are renamed to their append position (aligned to indices).
-        assert set(h5file["invalid_vector_channels/trace"].keys()) == {"0", "1"}
-        assert h5file["invalid_vector_channels/trace/0"][:].tolist() == [3.0, 4.0]
-        assert h5file["invalid_vector_channels/trace/1"][:].tolist() == [4.0, 5.0]
+        assert set(h5file["invalid/vector_channels/trace"].keys()) == {"0", "1"}
+        assert h5file["invalid/vector_channels/trace/0"][:].tolist() == [3.0, 4.0]
+        assert h5file["invalid/vector_channels/trace/1"][:].tolist() == [4.0, 5.0]
 
 
 def test_move_last_n_data_points_appends_across_retakes(tmp_path: Path) -> None:
@@ -92,17 +92,17 @@ def test_move_last_n_data_points_appends_across_retakes(tmp_path: Path) -> None:
         assert h5file["scan_parameters"].shape == (0, 1)
 
         # Invalid datasets accumulate both batches.
-        assert h5file["invalid_indices"][:].tolist() == [3, 4, 0, 1, 2]
-        assert h5file["invalid_scan_parameters"].shape == (5, 1)
+        assert h5file["invalid/indices"][:].tolist() == [3, 4, 0, 1, 2]
+        assert h5file["invalid/scan_parameters"].shape == (5, 1)
         # Vector datasets from the second batch use append positions 2, 3, 4.
-        assert set(h5file["invalid_vector_channels/trace"].keys()) == {
+        assert set(h5file["invalid/vector_channels/trace"].keys()) == {
             "0",
             "1",
             "2",
             "3",
             "4",
         }
-        assert h5file["invalid_vector_channels/trace/2"][:].tolist() == [0.0, 1.0]
+        assert h5file["invalid/vector_channels/trace/2"][:].tolist() == [0.0, 1.0]
 
 
 def test_move_last_n_data_points_noop_when_zero(tmp_path: Path) -> None:
@@ -111,4 +111,4 @@ def test_move_last_n_data_points_noop_when_zero(tmp_path: Path) -> None:
 
         assert _move_last_n_data_points_to_invalid(h5file, no_data_points=0) == []
         assert h5file.attrs["number_of_data_points"] == 3
-        assert "invalid_indices" not in h5file
+        assert "invalid" not in h5file

--- a/tests/server/data_access/test_experiment_data_repository.py
+++ b/tests/server/data_access/test_experiment_data_repository.py
@@ -1,9 +1,13 @@
 from pathlib import Path
+from types import SimpleNamespace
 
 import h5py  # type: ignore
 import numpy as np
+import pytest
 
+from icon.server.data_access.repositories import experiment_data_repository
 from icon.server.data_access.repositories.experiment_data_repository import (
+    ExperimentDataRepository,
     _move_last_n_data_points_to_invalid,
     write_results_to_dataset,
     write_scan_parameters_and_timestamp_to_dataset,
@@ -112,3 +116,41 @@ def test_move_last_n_data_points_noop_when_zero(tmp_path: Path) -> None:
         assert _move_last_n_data_points_to_invalid(h5file, no_data_points=0) == []
         assert h5file.attrs["number_of_data_points"] == 3
         assert "invalid" not in h5file
+
+
+def test_mark_data_points_as_invalid_emits_invalidated_event(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    with h5py.File(tmp_path / "results.h5", "w") as h5file:
+        _write_data_points(h5file, count=5)
+
+    monkeypatch.setattr(
+        experiment_data_repository,
+        "get_filename_by_job_id",
+        lambda _job_id: "results.h5",
+    )
+    monkeypatch.setattr(
+        experiment_data_repository,
+        "get_config",
+        lambda: SimpleNamespace(data=SimpleNamespace(results_dir=str(tmp_path))),
+    )
+    emitted: list[dict[str, object]] = []
+    monkeypatch.setattr(
+        experiment_data_repository, "emit_queue", SimpleNamespace(put=emitted.append)
+    )
+
+    moved = ExperimentDataRepository.mark_data_points_as_invalid(
+        job_id=7, no_data_points=2
+    )
+
+    assert moved == [3, 4]
+    assert emitted == [
+        {"event": "experiment_7_invalidated", "data": {"indices": [3, 4]}}
+    ]
+
+    # A call that invalidates nothing emits nothing.
+    assert (
+        ExperimentDataRepository.mark_data_points_as_invalid(job_id=7, no_data_points=0)
+        == []
+    )
+    assert len(emitted) == 1

--- a/tests/server/data_access/test_experiment_data_repository.py
+++ b/tests/server/data_access/test_experiment_data_repository.py
@@ -118,6 +118,55 @@ def test_move_last_n_data_points_noop_when_zero(tmp_path: Path) -> None:
         assert "invalid" not in h5file
 
 
+def test_freed_indices_accept_reacquired_data(tmp_path: Path) -> None:
+    """Re-acquisition at the freed indices must store the new values.
+
+    The vector write silently skips dataset names that already exist, so this
+    fails if invalidation leaves the live per-index vector datasets behind.
+    """
+    with h5py.File(tmp_path / "results.h5", "w") as h5file:
+        _write_data_points(h5file, count=5)
+        _move_last_n_data_points_to_invalid(h5file, no_data_points=2)
+
+        # Re-acquire the freed indices (3, 4) with new values, as a retake will.
+        for offset, index in enumerate((3, 4)):
+            number_of_data_points = 3 + offset
+            write_scan_parameters_and_timestamp_to_dataset(
+                h5file=h5file,
+                data_point_index=index,
+                scan_params={"freq": float(index)},
+                timestamp=f"2024-01-01T00:01:{index:02d}.000000",
+                number_of_data_points=number_of_data_points,
+            )
+            write_results_to_dataset(
+                h5file=h5file,
+                data_point_index=index,
+                result_channels={"counts": 100.0 + index},
+                number_of_data_points=number_of_data_points,
+            )
+            write_shot_channels_to_datasets(
+                h5file=h5file,
+                data_point_index=index,
+                shot_channels={"shots": [9] * NUMBER_OF_SHOTS},
+                number_of_data_points=number_of_data_points,
+                number_of_shots=NUMBER_OF_SHOTS,
+            )
+            write_vector_channels_to_datasets(
+                h5file=h5file,
+                data_point_index=index,
+                vector_channels={"trace": [100.0 + index]},
+            )
+
+        assert h5file["scan_parameters"].shape == (5, 1)
+        assert h5file["result_channels"]["counts"][3:].tolist() == [103.0, 104.0]
+        assert h5file["shot_channels/shots"][3:].tolist() == [
+            [9.0] * NUMBER_OF_SHOTS,
+            [9.0] * NUMBER_OF_SHOTS,
+        ]
+        assert h5file["vector_channels/trace/3"][:].tolist() == [103.0]
+        assert h5file["vector_channels/trace/4"][:].tolist() == [104.0]
+
+
 def test_mark_data_points_as_invalid_emits_invalidated_event(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/server/utils/test_types.py
+++ b/tests/server/utils/test_types.py
@@ -1,0 +1,26 @@
+import queue
+from typing import TYPE_CHECKING
+
+from icon.server.utils.types import DataPointToProcess
+
+if TYPE_CHECKING:
+    from icon.server.data_access.db_context.influxdb_v1 import DatabaseValueType
+
+
+def test_data_points_dispense_in_index_order() -> None:
+    """Data points dispense by index.
+
+    A tie on index must not fall back to comparing the (unorderable)
+    scan-parameter dicts.
+    """
+    q: queue.PriorityQueue[DataPointToProcess] = queue.PriorityQueue()
+    data_points: list[tuple[int, dict[str, DatabaseValueType]]] = [
+        (5, {"freq": 5.0}),
+        (3, {"freq": 3.0}),
+        (3, {"amp": 1.0}),
+        (0, {"freq": 0.0}),
+    ]
+    for index, scan_params in data_points:
+        q.put(DataPointToProcess(index=index, scan_params=scan_params))
+
+    assert [q.get().index for _ in range(4)] == [0, 3, 3, 5]


### PR DESCRIPTION
## 1. Summary

The *goal* of #19 (Add support for re-taking data points) and its HDF5 "invalid datasets" idea hold up well. Its proposed *queue mechanics* do not: almost every assumption the issue makes about the pipeline was changed or disproven while landing #17 (Add pause/resume functionality to experiment jobs). 

## 2. Where the original `#19` text is outdated or unsafe after `#17`

Each item below first shows what the original issue text says (or assumes) and what the `#17` experience taught us about it. The following **What we do instead** paragraph then gives the correction,

1. **"It should be clear that the data_points_to_process queue is a priority queue, already."** — It is not a priority queue. During `#17` we deliberately kept `_data_points_to_process` a plain FIFO and added the separate `_outdated_tasks` priority queue instead.

   **What we do instead:** make it a priority queue now, ordered by data-point index, as its own behaviour-neutral change — without it, re-queued points would run *after* the untaken points and land in the file out of time order.

2. **The issue's handler invalidates the HDF5 rows the moment the event arrives.** `#17`'s hardest bugs were exactly this shape: acting on state while the pipeline still has work in flight. Two things can still be moving when the event arrives, even though the job is paused: a point that the hardware started executing just before the pause (pausing only takes effect when a task is *taken from* the queue), and points that finished but whose file write is still sitting in the post-processing queue — being counted as "processed" does **not** mean "written to the file yet". Shrink the file at that moment and a late write re-extends it, leaving garbage rows and permanently out-of-order timestamps.

   **What we do instead:** before touching the file, the worker waits until every point it handed to the hardware has come back *and* every completed point is actually in the file (checked against the file itself), re-checking on every wait iteration that the job is still paused so the wait can never hang.

3. **The issue never mentions the ordering invariant.** The central review lesson of `#17`: index order must equal time order *in the stored data*, not just in the UI. Retaking means re-measuring old indices at a later time, which threatens exactly that.

   **What we do instead:** make this the first design decision. It works out cleanly because retake only ever rewinds the **tail**: once the pipeline is drained (item 2) and re-taken points are dispatched first (item 1), no newer-index point has been measured yet, so re-measuring the tail keeps the file in time order — with no changes to any reader.

4. **"Data points in the hardware worker for paused jobs [must be] put back into the data_points_to_process queue."** `#17` deliberately did the opposite: paused tasks wait in `_outdated_tasks` and are resubmitted on resume, keeping their already-generated sequence (regenerated only if parameters changed meanwhile).

   **What we do instead:** keep the merged `#17` behaviour for a plain pause/resume; only the retake handler moves those tasks back into `_data_points_to_process` — because after a retake they must be re-ordered behind the re-taken points.

5. **Re-queuing breaks job completion.** The scan loop decides "job done" by counting processed points against the number of scan combinations. A re-taken point completes twice, so with the issue's logic the job would be declared done while the re-takes are still pending — and since the file was shrunk, the run would end with rows *missing*.

   **What we do instead:** the worker keeps an explicit expected count that grows with each retake.

6. **The controller's "check paused, then enqueue" has a race.** The user can resume between the check and the worker consuming the event; the running scan loop would then invalidate the file mid-flight.

   **What we do instead:** the worker re-checks the paused status itself before acting, and drops the event otherwise.

7. **The `mark_data_points_as_invalid` sketch reads the scan values back out of the HDF5 file.** That round-trips the values through `float64`, losing their original type (an int comes back as a float) — while the worker already holds the exact submitted values in its scan-combination list. It also uses `FileLock`, which main has since replaced with the `h5_open` helper.

   **What we do instead:** return only the indices; rebuild exact values from the job's scan-combination list, which is deterministic. Use `h5_open` for locking.

8. **Continuous (realtime) scans: the issue asks both to support them and to grey the buttons out.** `#17` already had to exempt realtime scans from the staleness divert (paused realtime tasks still divert) — they manage their own regeneration and their indices only ever grow.

   **What we do instead:** leave continuous scans explicitly out of scope, enforced in three places (API raises, worker drops the event with a warning, frontend disables the buttons).

## 3. Work phases

1. Split the update-queue event types (pure refactor).
2. Make `_data_points_to_process` a priority queue by index (behaviour-neutral: points are already produced in index order).
3. HDF5: move the last N rows of every per-data-point dataset into an `invalid/` group (original index + timestamp preserved), shrink the live datasets. Readers need no changes because the live data stays dense.
4. Worker: on the retake event — verify still paused and not realtime; drain the pipeline (section 2, item 2); invalidate; re-queue the freed indices; bump the expected count.
5. API: `scans.retake_data_points(job_id, no_data_points)` with validation.
6. Frontend: the two buttons, disabled unless paused and not realtime.

Cost assessment: steps 1-3, 5, 6 are straightforward. Step 4 is not — it is the same class of drain/ordering reasoning that made `#17` tough, and it needs the same style of tests. It is one more layer of careful machinery on the same base, and realtime scans stay unsupported.

Alternatives considered (and rejected):

- **Fresh indices for re-taken points** (append them at the end, only flag the old rows as invalid): collides with the indices already assigned to the pending points, and leaves holes in the live data that every reader — frontend, API, fitting, external HDF5 users — would have to learn to skip.
- **Enforcing execution order in the hardware worker** (buffer tasks, dispatch strictly by index): solves ordering in general but is a pipeline redesign of its own — a heavier cousin of Route B's fix 3, which gets the same effect by feeding less instead of buffering more.
- **Flushing pending writes with a marker through the post-processing queue** (instead of checking the file): looks simpler, but does not cover a point still executing on the hardware, so the wait is needed anyway — the marker would only add machinery.

