### PR TITLE
feat: add 'Open Experiment Windows' browser setting

### DIFF
--- a/frontend/src/pages/settings.tsx
+++ b/frontend/src/pages/settings.tsx
@@ -44,6 +44,10 @@ export const SettingsPage = () => {
     "separateJobWindows",
     false,
   );
+  const [openExperimentWindows, setOpenExperimentWindows] = useBrowserSetting<boolean>(
+    "openExperimentWindows",
+    true,
+  );
 
   const tabParam = searchParams.get("tab");
   let tab = tabParam ? tabLabels.indexOf(tabParam) : -1;
@@ -259,6 +263,14 @@ export const SettingsPage = () => {
         />
       </TabPanel>
       <TabPanel value={tab} index={7}>
+        <BaseButton
+          label="Open Experiment Windows"
+          description="Automatically open a job window when a new experiment is submitted."
+          color={openExperimentWindows ? "success" : "inherit"}
+          onClick={() => setOpenExperimentWindows(!openExperimentWindows)}
+        >
+          {openExperimentWindows ? "True" : "False"}
+        </BaseButton>
         <BaseButton
           label="Use separate job windows"
           description="Open each job of the same experiment in a separate window."

--- a/frontend/src/utils/submitJob.ts
+++ b/frontend/src/utils/submitJob.ts
@@ -40,7 +40,9 @@ export const submitJob = (experimentId: string, scanInfoState: ScanInfoState) =>
     },
     (ack) => {
       const jobId = deserialize(ack as SerializedInteger);
-      openJobWindow(jobId, experimentId);
+      if (localStorage.getItem("openExperimentWindows") !== "false") {
+        openJobWindow(jobId, experimentId);
+      }
     },
   );
 };


### PR DESCRIPTION
Submitting a job automatically opened a job window showing the experiment data. Since the data is already visible in the data panel, this can be unwanted. A new toggle in Settings > Browser ('Open Experiment Windows', default on) now controls whether the window opens on job submission. 