### PR TITLE
Check if run cancelled before transitioning to PROCESSING state

### DIFF
--- a/src/icon/server/pre_processing/worker.py
+++ b/src/icon/server/pre_processing/worker.py
@@ -247,6 +247,12 @@ class PreProcessingWorker(multiprocessing.Process):
         isolated_lib_client: ExperimentLibraryClient,
     ) -> None:
         job = pre_processing_task.job
+
+        if job_run_cancelled_or_failed(
+            job_id=job.id,
+        ):
+            return
+
         JobRunRepository.update_run_by_id(
             run_id=pre_processing_task.job_run.id,
             status=JobRunStatus.PROCESSING,
@@ -255,11 +261,6 @@ class PreProcessingWorker(multiprocessing.Process):
         namespace = ExperimentIdentifier.from_str(job.experiment_source.experiment_id)
         # empty update queue
         self._handle_parameter_updates(pre_processing_task, namespace=namespace)
-
-        if job_run_cancelled_or_failed(
-            job_id=job.id,
-        ):
-            return
 
         change_process_priority(pre_processing_task.priority)
 


### PR DESCRIPTION
Fixes #119 

**Problem Statement** 

Currently, the processing worker immediately transitions the state of a job run to the PROCESSING state for every task it consumes from the queue. In case a job was cancelled while it was queued, the cancellation will be ignored. 

**Solution Proposal**

Move the cancellation check at the beginning of the processing sequence of the pre-processing worker.