### PR TITLE
Wrap all access to h5 files in a lock

### DIFF
--- a/src/icon/server/data_access/repositories/experiment_data_repository.py
+++ b/src/icon/server/data_access/repositories/experiment_data_repository.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import threading
 import time
 from collections.abc import Iterator
 from contextlib import contextmanager
@@ -819,16 +820,18 @@ def get_result_channels_dataset(
 
 POLL_INTERVAL = 0.05
 
+_HDF5_GLOBAL_LOCK = threading.RLock()
 
 @contextmanager
 def h5_open(path: Path, mode: str, **kwargs: Any) -> Iterator[h5py.File]:
-    while True:
-        try:
-            with h5py.File(str(path), mode, **kwargs) as h5file:
-                yield h5file
-            break
-        except (OSError, FileNotFoundError):
-            time.sleep(POLL_INTERVAL)
+    with _HDF5_GLOBAL_LOCK:
+        while True:
+            try:
+                with h5py.File(str(path), mode, **kwargs) as h5file:
+                    yield h5file
+                break
+            except (OSError, FileNotFoundError):
+                time.sleep(POLL_INTERVAL)
 
 
 def _read_fits_from_hdf5(

--- a/src/icon/server/data_access/repositories/experiment_data_repository.py
+++ b/src/icon/server/data_access/repositories/experiment_data_repository.py
@@ -822,6 +822,7 @@ POLL_INTERVAL = 0.05
 
 _HDF5_GLOBAL_LOCK = threading.RLock()
 
+
 @contextmanager
 def h5_open(path: Path, mode: str, **kwargs: Any) -> Iterator[h5py.File]:
     with _HDF5_GLOBAL_LOCK:


### PR DESCRIPTION
## Background

In #91 the hdf5 file access pattern was changed and the locking mechanism removed. This was done due to h5py's [claim to be thread safe](https://docs.h5py.org/en/stable/threads.html).

## Problem Statement

Icon experienced sporadic SIGSEGV when a hdf5 file was read from multiple clients simultaneously. With GDB the SIGSEGV trigger could be localized to the hdf5 library
```
Thread 18 "python" received signal SIGSEGV, Segmentation fault.
0x00007ffff6f308c0 in H5F_addr_decode () from /tmp/h5/.venv/lib/python3.12/site-packages/h5py/../h5py.libs/libhdf5-9e18f0c6.so.320.0.0
```
More details: https://github.com/h5py/h5py/issues/2920

## Solution Proposal

For now, we wrap the `h5_open` context manager into a lock, such that hdf5 file access between threads in a process is serialized. 
