### PR TITLE
Exempt realtime scans from the hardware worker's staleness divert

### DIFF
--- a/src/icon/server/hardware_processing/worker.py
+++ b/src/icon/server/hardware_processing/worker.py
@@ -13,6 +13,9 @@ import socketio.exceptions
 
 from icon.config.config import get_config
 from icon.server.data_access.models.enums import DeviceStatus, JobRunStatus
+from icon.server.data_access.models.sqlite.scan_parameter import (
+    contains_realtime_parameter,
+)
 from icon.server.data_access.repositories.device_repository import DeviceRepository
 from icon.server.data_access.repositories.job_run_repository import (
     JobRunRepository,
@@ -71,13 +74,16 @@ def should_divert_task(
 ) -> bool:
     """Whether the hardware worker should divert a task back to pre-processing.
 
-    A task is diverted when its job is paused, or when its parameters went stale
-    (it was built before the last parameter update).
+    A paused job always diverts. Otherwise a task is diverted when its parameters
+    went stale (it was built before the last parameter update) -- except for realtime
+    scans, whose sequences the realtime handler regenerates in place, so diverting a
+    stale realtime task would just bounce it back and forth in a tight loop.
     """
-    return (
-        task.created < parameter_update_timestamp
-        or job_run_status == JobRunStatus.PAUSED
-    )
+    if job_run_status == JobRunStatus.PAUSED:
+        return True
+    if contains_realtime_parameter(task.pre_processing_task.scan_parameters):
+        return False
+    return task.created < parameter_update_timestamp
 
 
 class HardwareProcessingWorker(multiprocessing.Process):

--- a/tests/server/pre_processing/test_worker.py
+++ b/tests/server/pre_processing/test_worker.py
@@ -3,8 +3,6 @@ from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
-import pytest
-
 from icon.server.data_access.models.enums import JobRunStatus
 from icon.server.hardware_processing.worker import should_divert_task
 from icon.server.pre_processing.worker import PreProcessingWorker
@@ -35,11 +33,15 @@ class _FakeTask:
         self.priority = 0
         self.scanned_params: dict = {}
         self.sequence_json = sequence_json
+        # Mirror PreProcessingTask, which exposes scan_parameters both as its own field
+        # and via .job (the scheduler sets the field to job.scan_parameters).
+        scan_parameters = _scan_parameters(realtime=realtime)
         self.pre_processing_task = SimpleNamespace(
+            scan_parameters=scan_parameters,
             job=SimpleNamespace(
                 number_of_shots=100,
-                scan_parameters=_scan_parameters(realtime=realtime),
-            )
+                scan_parameters=scan_parameters,
+            ),
         )
 
     def __lt__(self, other: "_FakeTask") -> bool:
@@ -162,11 +164,6 @@ def test_regenerate_uses_updated_parameters_after_pause() -> None:
     assert generate.call_args.kwargs["parameter_dict"]["freq"] == UPDATED_FREQ
 
 
-@pytest.mark.xfail(
-    reason="On resume after a parameter update, the consumer resubmits the stale "
-    "realtime task and the hardware worker re-diverts it, looping forever.",
-    strict=True,
-)
 def test_no_tight_loop_on_realtime_resume() -> None:
     """The consumer<->hardware-worker round-trip must terminate for a realtime scan.
 


### PR DESCRIPTION
Ref #83

This approach ignores the parameter update for all real-time WorkerProcessingTasks that are inside the WorkerProcessingQueue (WPQ) at the time the parameter update is invoked. Therefore, there is generally a delay of ~20 data points (default WPQ max size) before the parameter update is actually applied. This approach is simpler than #136 and does not have the race condition between handling the incoming queue of outdated tasks and producing new worker processing tasks which can lead to data points being produced out of chronological order. 