### PR TITLE
fix: reset scanned device parameters to pre-scan value on scan end

### DIFF
--- a/src/icon/server/hardware_processing/task.py
+++ b/src/icon/server/hardware_processing/task.py
@@ -22,6 +22,10 @@ class HardwareProcessingTask(pydantic.BaseModel):
     sequence_json: str
     src_dir: str | None
     created: datetime
+    restore_device_values: bool = False
+    """When True, this task is a teardown marker: the hardware worker restores each
+    scanned device parameter to the value it had before the scan started, instead of
+    running a data point."""
     if TYPE_CHECKING:
         processed_data_points: Queue[HardwareProcessingTask]
         data_points_to_process: Queue[tuple[int, dict[str, DatabaseValueType]]]

--- a/src/icon/server/hardware_processing/worker.py
+++ b/src/icon/server/hardware_processing/worker.py
@@ -78,6 +78,10 @@ class HardwareProcessingWorker(multiprocessing.Process):
         self._post_processing_queue = post_processing_queue
         self._manager = manager
         self._pydase_clients: dict[str, pydase.Client] = {}
+        # Per-job snapshot of each scanned device parameter's value *before* the scan
+        # touched it, so it can be restored once the job finishes or is cancelled.
+        # Keyed by job_id -> {parameter_id: original_value}.
+        self._original_device_values: dict[int, dict[str, DatabaseValueType]] = {}
 
         self._hardware_controller = hardware_controller
 
@@ -120,7 +124,7 @@ class HardwareProcessingWorker(multiprocessing.Process):
         )
 
     def _set_pydase_service_values(
-        self, scanned_params: dict[str, DatabaseValueType]
+        self, scanned_params: dict[str, DatabaseValueType], job_id: int
     ) -> None:
         for param, value in scanned_params.items():
             device_name, access_path = parse_parameter_id(param_id=param)
@@ -138,11 +142,57 @@ class HardwareProcessingWorker(multiprocessing.Process):
             if device_name not in self._pydase_clients:
                 self._add_device(device=device)
 
+            # Snapshot the pre-scan value the first time this job writes this parameter,
+            # so it can be restored when the job finishes or is cancelled.
+            captured = self._original_device_values.setdefault(job_id, {})
+            if param not in captured:
+                captured[param] = self._pydase_clients[device.name].get_value(
+                    access_path=access_path
+                )
+
             self._update_pydase_service_parameter(
                 device=device,
                 access_path=access_path,
                 new_value=value,
             )
+
+    def _restore_device_values(self, job_id: int) -> None:
+        """Restore each scanned device parameter of a job to its pre-scan value.
+
+        Best-effort: a device that has since become disabled or unreachable is logged
+        and skipped rather than crashing the worker. Runs on both normal completion and
+        cancellation, so devices never remain stuck at a mid-scan value.
+        """
+        for param, value in self._original_device_values.pop(job_id, {}).items():
+            device_name, access_path = parse_parameter_id(param_id=param)
+
+            if device_name is None:
+                continue
+
+            try:
+                device = DeviceRepository.get_device_by_name(name=device_name)
+
+                if device.status != DeviceStatus.ENABLED:
+                    logger.warning(
+                        "Not restoring %r: device %r is disabled.", param, device_name
+                    )
+                    continue
+
+                if device_name not in self._pydase_clients:
+                    self._add_device(device=device)
+
+                self._update_pydase_service_parameter(
+                    device=device,
+                    access_path=access_path,
+                    new_value=value,
+                )
+            except Exception:
+                logger.exception(
+                    "Failed to restore %r of device %r to %r.",
+                    access_path,
+                    device_name,
+                    value,
+                )
 
     @handle_keyboard_interrupt(logger)
     def run(self) -> None:
@@ -157,6 +207,13 @@ class HardwareProcessingWorker(multiprocessing.Process):
 
         while True:
             task = self._queue.get()
+
+            # Teardown marker submitted once per job: restore scanned device parameters
+            # to their pre-scan values. Handled before the cancel short-circuit below so
+            # it also runs for cancelled jobs.
+            if task.restore_device_values:
+                self._restore_device_values(job_id=task.pre_processing_task.job.id)
+                continue
 
             if job_run_cancelled_or_failed(
                 job_id=task.pre_processing_task.job.id,
@@ -173,7 +230,10 @@ class HardwareProcessingWorker(multiprocessing.Process):
                 task.outdated_tasks.put(task)
                 continue
             try:
-                self._set_pydase_service_values(scanned_params=task.scanned_params)
+                self._set_pydase_service_values(
+                    scanned_params=task.scanned_params,
+                    job_id=task.pre_processing_task.job.id,
+                )
 
                 timestamp = datetime.now(timezone)
                 self._hardware_controller.send(data=task.sequence_json.encode("utf-8"))

--- a/src/icon/server/pre_processing/worker.py
+++ b/src/icon/server/pre_processing/worker.py
@@ -239,9 +239,40 @@ class PreProcessingWorker(multiprocessing.Process):
                             log=str(e),
                         )
                 finally:
+                    # Restore scanned device parameters to their pre-scan values. Runs
+                    # on normal completion, failure, and cancellation alike. No-op when
+                    # the scan touched no device parameters.
+                    self._submit_device_restore_task(pre_processing_task)
                     JobRepository.update_job_status(
                         job=pre_processing_task.job, status=JobStatus.PROCESSED
                     )
+
+    def _submit_device_restore_task(
+        self, pre_processing_task: PreProcessingTask
+    ) -> None:
+        """Enqueue a teardown marker so the hardware worker restores device values.
+
+        Device values are written only by the (single) hardware worker, so the restore
+        is routed through it via a marker task rather than written from here — this keeps
+        the hardware worker the sole writer and avoids racing with in-flight scan points.
+        """
+        now = datetime.now(timezone)
+        self._hw_processing_queue.put(
+            HardwareProcessingTask(
+                data_point_index=-1,
+                pre_processing_task=pre_processing_task,
+                priority=pre_processing_task.priority,
+                global_parameter_timestamp=now,
+                scanned_params={},
+                src_dir=None,
+                sequence_json="",
+                processed_data_points=self._processed_data_points,
+                data_points_to_process=self._data_points_to_process,
+                outdated_tasks=self._outdated_tasks,
+                created=now,
+                restore_device_values=True,
+            )
+        )
 
     def _process_task(
         self,

--- a/tests/server/hardware_processing/test_worker_device_restore.py
+++ b/tests/server/hardware_processing/test_worker_device_restore.py
@@ -1,0 +1,120 @@
+"""Unit tests for scanned-device-parameter capture/restore in the hardware worker.
+
+These exercise the pure capture/restore logic directly on a `HardwareProcessingWorker`
+instance without starting the process or touching real devices: the pydase clients are
+replaced with an in-memory fake and `DeviceRepository.get_device_by_name` is patched.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from icon.server.data_access.models.enums import DeviceStatus
+from icon.server.hardware_processing import worker as worker_module
+from icon.server.hardware_processing.worker import HardwareProcessingWorker
+
+PRE_SCAN_VALUE = 1.0
+FIRST_SCAN_POINT = 5.0
+SECOND_SCAN_POINT = 8.0
+PARAM = "Device(dev) foo"
+
+
+class FakeClient:
+    """In-memory stand-in for a pydase client backed by a dict of values."""
+
+    def __init__(self, values: dict[str, object]) -> None:
+        self.values = values
+
+    def get_value(self, *, access_path: str) -> object:
+        return self.values[access_path]
+
+    def update_value(self, *, access_path: str, new_value: object) -> None:
+        self.values[access_path] = new_value
+
+
+@pytest.fixture
+def device() -> SimpleNamespace:
+    return SimpleNamespace(
+        name="dev",
+        url="ws://localhost:8001",
+        status=DeviceStatus.ENABLED,
+        retry_attempts=3,
+        retry_delay_seconds=0.0,
+    )
+
+
+@pytest.fixture
+def worker(
+    device: SimpleNamespace, monkeypatch: pytest.MonkeyPatch
+) -> HardwareProcessingWorker:
+    def get_device_by_name(*, name: str) -> SimpleNamespace:
+        assert name == device.name
+        return device
+
+    monkeypatch.setattr(
+        worker_module.DeviceRepository,
+        "get_device_by_name",
+        staticmethod(get_device_by_name),
+    )
+    w = HardwareProcessingWorker(
+        hardware_processing_queue=None,  # type: ignore[arg-type]
+        post_processing_queue=None,  # type: ignore[arg-type]
+        manager=None,  # type: ignore[arg-type]
+        hardware_controller=None,  # type: ignore[arg-type]
+    )
+    w._pydase_clients = {"dev": FakeClient({"foo": PRE_SCAN_VALUE})}  # type: ignore[dict-item]
+    return w
+
+
+def test_restore_returns_device_to_pre_scan_value(
+    worker: HardwareProcessingWorker,
+) -> None:
+    client = worker._pydase_clients["dev"]
+
+    worker._set_pydase_service_values(scanned_params={PARAM: FIRST_SCAN_POINT}, job_id=1)
+    worker._set_pydase_service_values(
+        scanned_params={PARAM: SECOND_SCAN_POINT}, job_id=1
+    )
+    assert client.get_value(access_path="foo") == SECOND_SCAN_POINT
+
+    worker._restore_device_values(job_id=1)
+
+    # Restored to the value captured before the first scan write, not the last point.
+    assert client.get_value(access_path="foo") == PRE_SCAN_VALUE
+    # Snapshot is cleaned up after restore.
+    assert 1 not in worker._original_device_values
+
+
+def test_original_value_captured_only_once(worker: HardwareProcessingWorker) -> None:
+    worker._set_pydase_service_values(scanned_params={PARAM: FIRST_SCAN_POINT}, job_id=1)
+    worker._set_pydase_service_values(
+        scanned_params={PARAM: SECOND_SCAN_POINT}, job_id=1
+    )
+    assert worker._original_device_values[1][PARAM] == PRE_SCAN_VALUE
+
+
+def test_restore_without_capture_is_noop(worker: HardwareProcessingWorker) -> None:
+    # No scan writes happened for this job (e.g. cancelled before any point ran).
+    worker._restore_device_values(job_id=999)
+    assert worker._pydase_clients["dev"].get_value(access_path="foo") == PRE_SCAN_VALUE
+
+
+def test_non_device_params_are_ignored(worker: HardwareProcessingWorker) -> None:
+    worker._set_pydase_service_values(scanned_params={"bare_param": 3.0}, job_id=2)
+    assert worker._original_device_values.get(2, {}) == {}
+
+
+def test_restore_is_lenient_when_device_disabled(
+    worker: HardwareProcessingWorker, device: SimpleNamespace
+) -> None:
+    worker._set_pydase_service_values(scanned_params={PARAM: FIRST_SCAN_POINT}, job_id=1)
+
+    # Device becomes disabled between scan and teardown.
+    device.status = DeviceStatus.DISABLED
+
+    # Must not raise, and must not write the disabled device.
+    worker._restore_device_values(job_id=1)
+    assert worker._pydase_clients["dev"].get_value(access_path="foo") == FIRST_SCAN_POINT
+    assert 1 not in worker._original_device_values


### PR DESCRIPTION
This PR adresses issue #143

Scanning a pydase device parameter physically pushes each scan point to the stateful device via client.update_value; nothing pushed the original value back, so the device was left at the last mid-scan value after a scan finished or was cancelled. (Global/local shared params are unaffected: their scan values are only injected transiently into sequence generation and never overwrite the stored value.)

Capture and restore both happen in the single HardwareProcessingWorker (the sole device writer, so restore can't race an in-flight scan-point write): it snapshots each scanned device param's value the first time it writes it, keyed by job id. The PreProcessingWorker submits a teardown 'restore' task in its run() finally, so it fires on normal completion, failure, and cancellation, including the realtime scan path. The hardware worker handles that marker before its cancel short-circuit and writes the originals back best-effort (a since-disabled/unreachable device is logged, not fatal).