### PR TITLE
Omit json_sequences from default get_experiment_data_by_job_id response.

### DIFF
--- a/src/icon/server/api/experiment_data_controller.py
+++ b/src/icon/server/api/experiment_data_controller.py
@@ -26,6 +26,7 @@ class ExperimentDataController(pydase.DataService):
         self,
         job_id: int,
         max_transfer_bytes: int = 50_000_000,
+        *,
         include_json_sequences: bool = False,
     ) -> dict[str, Any]:
         """Return experiment data for a given job.

--- a/src/icon/server/api/experiment_data_controller.py
+++ b/src/icon/server/api/experiment_data_controller.py
@@ -23,7 +23,10 @@ class ExperimentDataController(pydase.DataService):
     """
 
     async def get_experiment_data_by_job_id(
-        self, job_id: int, max_transfer_bytes: int = 50_000_000
+        self,
+        job_id: int,
+        max_transfer_bytes: int = 50_000_000,
+        include_json_sequences: bool = False,
     ) -> dict[str, Any]:
         """Return experiment data for a given job.
 
@@ -33,6 +36,11 @@ class ExperimentDataController(pydase.DataService):
                 size in bytes.  The number of data points loaded is
                 derived from HDF5 metadata so that the response stays
                 within this budget.  Defaults to 50 MB.
+            include_json_sequences: If True, include per-point pulse
+                ``sequence_json`` blobs in the response.  Defaults to False
+                because those strings dominate the payload for large scans
+                (~tens of MB) and are not needed for plotting/fitting; live
+                updates still carry ``sequence_json`` per data point.
 
         Returns:
             The experiment data linked to the job as a dict resulting
@@ -44,6 +52,7 @@ class ExperimentDataController(pydase.DataService):
             ExperimentDataRepository.get_experiment_data_by_job_id,
             job_id=job_id,
             max_transfer_bytes=max_transfer_bytes,
+            include_json_sequences=include_json_sequences,
         )
         return asdict(result)
 

--- a/src/icon/server/data_access/repositories/experiment_data_repository.py
+++ b/src/icon/server/data_access/repositories/experiment_data_repository.py
@@ -590,6 +590,7 @@ class ExperimentDataRepository:
         *,
         job_id: int,
         max_transfer_bytes: int = 50_000_000,
+        include_json_sequences: bool = False,
     ) -> ExperimentData:
         """Load stored data for a job from its HDF5 file.
 
@@ -602,6 +603,10 @@ class ExperimentDataRepository:
             job_id: Job identifier.
             max_transfer_bytes: Approximate cap on the serialised payload
                 size in bytes.  Defaults to 50 MB.
+            include_json_sequences: If True, load ``sequence_json`` entries
+                into ``json_sequences``.  Defaults to False — those blobs are
+                large (~27 KB each, one per changed point) and are omitted
+                from the default RPC response.
 
         Returns:
             Experiment data payload suitable for the API.
@@ -745,16 +750,17 @@ class ExperimentDataRepository:
                     )
                 }
 
-            sequence_json_dataset = cast(
-                "h5py.Dataset | tuple[()]", h5file.get("sequence_json", ())
-            )
-            data.json_sequences = [
-                [
-                    cast("np.int32", entry["index"]).item(),
-                    entry["Sequence"].decode(),
+            if include_json_sequences:
+                sequence_json_dataset = cast(
+                    "h5py.Dataset | tuple[()]", h5file.get("sequence_json", ())
+                )
+                data.json_sequences = [
+                    [
+                        cast("np.int32", entry["index"]).item(),
+                        entry["Sequence"].decode(),
+                    ]
+                    for entry in sequence_json_dataset
                 ]
-                for entry in sequence_json_dataset
-            ]
             data.parameters = extract_parameter_values(h5file)
             data.fits = _read_fits_from_hdf5(h5file)
         return data


### PR DESCRIPTION
Per-point sequence JSON can be tens of MB for large scans and stalls RPC/pydase serialization. Keep sequences on disk and in live updates; opt in with include_json_sequences=True.

## Summary
- ``get_experiment_data_by_job_id`` no longer loads ``sequence_json`` into the response by default (``include_json_sequences=False``).
- Large multi-axis scans were shipping one ~27 KB pulse-sequence string per point (e.g. ~35 MB for 1326 points), which stalls pydase/websocket serialization even though scalar channels are tiny.
- Sequences remain in HDF5 and on live per-point updates; pass ``include_json_sequences=True`` when a full historical sequence list is needed.