### PR TITLE
Make the Zedboard RPC timeout configurable

### DIFF
--- a/src/icon/server/hardware_processing/zedboard_controller.py
+++ b/src/icon/server/hardware_processing/zedboard_controller.py
@@ -20,7 +20,7 @@ logger = logging.getLogger(__name__)
 
 
 class ZedboardController(HardwareController):
-    def __init__(self, *, host: str, port: int, timeout: int = 60) -> None:
+    def __init__(self, *, host: str, port: int, timeout: int = 5) -> None:
         """Initialise the controller.
 
         Args:

--- a/src/icon/server/hardware_processing/zedboard_controller.py
+++ b/src/icon/server/hardware_processing/zedboard_controller.py
@@ -20,15 +20,24 @@ logger = logging.getLogger(__name__)
 
 
 class ZedboardController(HardwareController):
-    def __init__(self, *, host: str, port: int) -> None:
+    def __init__(self, *, host: str, port: int, timeout: int = 60) -> None:
+        """Initialise the controller.
+
+        Args:
+            host: Hostname of the Zedboard.
+            port: Port the Zedboard RPC server listens on.
+            timeout: RPC timeout in seconds for calls such as runExperiment. The
+                tiqi_zedboard default of 5 s is tight for slower experiments.
+        """
         self._host = host
         self._port = port
+        self._timeout = timeout
         self._zedboard: tiqi_zedboard.zedboard.Zedboard | None = None
 
     def connect(self) -> None:
         logger.info("Connecting to the Zedboard")
         self._zedboard = tiqi_zedboard.zedboard.Zedboard(
-            hostname=self._host, port=self._port
+            hostname=self._host, port=self._port, timeout=self._timeout
         )
         if not self.connected:
             logger.warning("Failed to connect to the Zedboard")

--- a/src/icon/server/hardware_processing/zedboard_controller.py
+++ b/src/icon/server/hardware_processing/zedboard_controller.py
@@ -26,8 +26,7 @@ class ZedboardController(HardwareController):
         Args:
             host: Hostname of the Zedboard.
             port: Port the Zedboard RPC server listens on.
-            timeout: RPC timeout in seconds for calls such as runExperiment. The
-                tiqi_zedboard default of 5 s is tight for slower experiments.
+            timeout: RPC timeout in seconds for calls such as runExperiment. Configurable in the config file.
         """
         self._host = host
         self._port = port


### PR DESCRIPTION
tiqi_zedboard defaults its RPC timeout to 5s, which is tight for slower experiments. The timeout applies to every RPC call, including the runExperiment call behind ZedboardController.receive().

Add a `timeout` parameter to ZedboardController (default 60s) and pass it to the Zedboard client, which forwards it to tiqi_rpc.Client for both the initial connect and each subsequent call.

Since the device-emulation refactor, controllers are constructed from hardware.devices[].args, so the timeout is configured per device rather than as a global config field:

    hardware:
      devices:
      - id: zedboard
        controller_class: ZedboardController
        args:
          host: ...
          port: ...
          timeout: 60

Devices.reload() already rebuilds and reconnects a device whose args change, so no extra reconnect check in StatusController is needed.